### PR TITLE
fix: Prevent wing count corruption from webhook re-processing

### DIFF
--- a/functions/src/model/utils.test.ts
+++ b/functions/src/model/utils.test.ts
@@ -6,7 +6,12 @@ const cases: [input: string, expected: string | null][] = [
     ["One\nTwo\nThree", null],
     ["🪂 Example Wing", "Example Wing"],
     ["One\n🪂 Example Wing\nThree", "Example Wing"],
-    [" 🪂 Not start of line", null]
+    [" 🪂 Not start of line", null],
+    ["🪂 Buzz Z6", "Buzz Z6"],
+    ["🪂 Advance Xi 3", "Advance Xi 3"],
+    ["🪂 Susi  44 flights / 52h45", "Susi"],
+    ["🪂 Buzz Z6  8 flights / 12h30", "Buzz Z6"],
+    ["🪂 Advance Xi 3  12 flights / 18h45", "Advance Xi 3"],
 ]
 
 test.each(cases)('extractWing(\"%s\") = \"%s\"', (input, expected) => {

--- a/functions/src/model/utils.ts
+++ b/functions/src/model/utils.ts
@@ -1,9 +1,9 @@
 export function extractWing(description: String): string | null {
     const matches = description
         .split("\n")
-        .map((line) => line.match(/^🪂 ([a-zA-Z ]*)/g))
-        .filter(match => match != null && match.length > 0)
-        .map((line) => line!![0].replace("🪂 ", ""))
+        .map((line) => line.match(/^🪂 (.+?)(?:\s{2,}\d|\s+\d+ flights?|$)/))
+        .filter(match => match != null)
+        .map((match) => match!![1].trim())
 
     if (matches.length == 0) {
         return null

--- a/functions/src/tasks/fetchAllActivities/StravaActivityToFlightConverter.ts
+++ b/functions/src/tasks/fetchAllActivities/StravaActivityToFlightConverter.ts
@@ -13,15 +13,15 @@ export class StravaActivityToFlightConverter {
 
         const matches = stravaActivity.description
             .split("\n")
-            .map((line) => line.match(/^🪂 ([a-zA-Z ]*)/g))
-            .filter(match => match != null && match.length > 0)
-            .map((line) => line!![0].replace("🪂 ", ""))
+            .map((line) => line.match(/^🪂 (.+?)(?:\s{2,}\d|\s+\d+ flights?|$)/))
+            .filter(match => match != null)
+            .map((match) => match!![1].trim())
 
         if (matches.length == 0) {
             return failure(`Couldn't extract wing from description=${stravaActivity.description}`)
         }
 
-        const wing = matches[0].trim()
+        const wing = matches[0]
 
         const initial: FlightRowInitial = {
             pilot_id: parseInt(pilotId.toString()),

--- a/functions/src/tasks/utils/stravaConverter.ts
+++ b/functions/src/tasks/utils/stravaConverter.ts
@@ -12,15 +12,15 @@ export async function convertStravaActivityToFlight(pilotId: number, stravaActiv
         // Extract wing from description
         const matches = stravaActivity.description
             .split("\n")
-            .map((line) => line.match(/^🪂 ([a-zA-Z ]*)/g))
-            .filter(match => match != null && match.length > 0)
-            .map((line) => line!![0].replace("🪂 ", ""));
+            .map((line) => line.match(/^🪂 (.+?)(?:\s{2,}\d|\s+\d+ flights?|$)/))
+            .filter(match => match != null)
+            .map((match) => match!![1].trim());
 
         if (matches.length === 0) {
             return failed(`Couldn't extract wing from description=${stravaActivity.description}`);
         }
 
-        const wing = matches[0].trim();
+        const wing = matches[0];
 
         // Decode polyline
         const tuples: LatLngTuple[] = decode(stravaActivity.map.polyline);


### PR DESCRIPTION
## Summary
- Skip `UpdateSingleActivity` for webhook "update" events when flight already exists, preventing wing name corruption from re-extracting from formatted descriptions
- Improve wing extraction regex to handle numbers/special chars (e.g. "Buzz Z6", "Advance Xi 3") and formatted descriptions with padded stats
- Add test coverage for edge cases (formatted descriptions, numeric wing names)

## Root Cause
When Strava sends a follow-up "update" webhook after a "create", the handler re-fetches the activity whose description has already been formatted with padded stats (`🪂 Susi  44 flights / 52h45`). The regex `[a-zA-Z ]*` captures the padding spaces, corrupting the wing name to `"Susi  "`. The upsert overwrites the wing, and the count query `WHERE wing = 'Susi  '` finds only 1 flight.

## Test plan
- [x] Unit tests pass (10/10 in `utils.test.ts`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Deploy and verify webhook handles create+update events correctly
- [ ] Verify wing count stays correct after Strava sends follow-up update webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)