### PR TITLE
fix: Handle slug collisions in Sites.upsert

### DIFF
--- a/common/src/database/Sites.ts
+++ b/common/src/database/Sites.ts
@@ -9,28 +9,46 @@ export namespace Sites {
                 for (const site of sites) {
                     console.log(`Upserting site=${JSON.stringify(site)}`)
                     try {
+                        // sites has two unique constraints: ffvl_sid (primary
+                        // key) and slug. Conflicts were only handled for
+                        // ffvl_sid, so a site whose slug was already held by a
+                        // *different* ffvl_sid raised sites_slug_key and was
+                        // dropped. That is reachable with real FFVL data: slug
+                        // is slugify(toponym), and slugify strips every
+                        // non-alphanumeric character, so two distinct sites
+                        // sharing a toponym — or differing only by accents or
+                        // punctuation — collapse to the same slug.
+                        //
+                        // Slug uniqueness has to hold: /sites/[site_slug]
+                        // resolves a site via Sites.getForSlug, so duplicates
+                        // would make that URL ambiguous. Instead the slug is
+                        // suffixed with the ffvl_sid when another site already
+                        // owns it. Deciding this inside the statement keeps it
+                        // atomic — a read-then-write would race — and the
+                        // whichever-site-got-there-first keeps the clean URL.
                         await database.query(`
                                     insert into sites(ffvl_sid, slug, name, lat, lng, alt, nearest_balise_id, polygon)
-                                    values ($1, $2, $3, $4, $5, $6, $7, $8)
+                                    values ($1,
+                                            case
+                                                when exists (select 1
+                                                             from sites
+                                                             where slug = $2
+                                                               and ffvl_sid <> $1)
+                                                    then $2 || '-' || $1
+                                                else $2
+                                                end,
+                                            $3, $4, $5, $6, $7, $8)
                                     on conflict(ffvl_sid)
-                                        do update set slug=$9,
-                                                      name=$10,
-                                                      lat=$11,
-                                                      lng=$12,
-                                                      alt=$13,
-                                                      nearest_balise_id=$14,
-                                                      polygon=$15
+                                        do update set slug=excluded.slug,
+                                                      name=excluded.name,
+                                                      lat=excluded.lat,
+                                                      lng=excluded.lng,
+                                                      alt=excluded.alt,
+                                                      nearest_balise_id=excluded.nearest_balise_id,
+                                                      polygon=excluded.polygon
                             `,
                             [
                                 site.ffvl_sid,
-                                site.slug,
-                                site.name,
-                                site.lat,
-                                site.lng,
-                                site.alt,
-                                site.nearest_balise_id,
-                                site.polygon,
-
                                 site.slug,
                                 site.name,
                                 site.lat,

--- a/functions/src/model/database/Sites.test.ts
+++ b/functions/src/model/database/Sites.test.ts
@@ -1,8 +1,9 @@
 import {expect, test} from "vitest";
 import {TestContainer} from "./generateContainer.test";
-import {Site, isSuccess} from "@parastats/common";
+import {Site} from "@parastats/common";
 import {Sites} from "./Sites";
 import {Mocks} from "./Mocks.test";
+import {end, withPooledClient} from "./client";
 
 
 test('Sites.upsert() ', async () => {
@@ -31,14 +32,50 @@ test('Sites.upsert() ', async () => {
     await container?.stop()
 })
 
+test('Sites.upsert() disambiguates a slug already held by another site', async () => {
+    const container = await TestContainer.generateEmpty()
+
+    // create_sites.sql seeds ffvl_sid=1 with slug chamonix---plan-praz---brevent.
+    // Mocks.planpraz carries that same slug under a different ffvl_sid (123) —
+    // the shape real FFVL data produces when two sites share a toponym, since
+    // slug is slugify(toponym). This used to raise sites_slug_key and drop the
+    // site entirely.
+    const [, upsertError] = await Sites.upsert([Mocks.planpraz])
+    expect(upsertError).toBeUndefined()
+
+    const rows = await withPooledClient(async (client) =>
+        (await client.query<{ ffvl_sid: string, slug: string }>(
+            "select ffvl_sid, slug from sites where ffvl_sid in ('1', $1) order by ffvl_sid",
+            [Mocks.planpraz.ffvl_sid]
+        )).rows.map(row => row.reify())
+    )
+
+    // The incumbent keeps the clean URL; the newcomer is suffixed with its id.
+    expect(rows).toStrictEqual([
+        {ffvl_sid: "1", slug: "chamonix---plan-praz---brevent"},
+        {ffvl_sid: "123", slug: "chamonix---plan-praz---brevent-123"},
+    ])
+
+    // Re-running the sync must be idempotent, not append another suffix.
+    const [, repeatError] = await Sites.upsert([Mocks.planpraz])
+    expect(repeatError).toBeUndefined()
+
+    const repeated = await withPooledClient(async (client) =>
+        (await client.query<{ slug: string }>(
+            "select slug from sites where ffvl_sid = $1", [Mocks.planpraz.ffvl_sid]
+        )).rows.map(row => row.reify().slug)
+    )
+    expect(repeated).toStrictEqual(["chamonix---plan-praz---brevent-123"])
+
+    await end()
+    await container?.stop()
+})
+
 test('Sites.getIdOfCloset() ', async () => {
     const container = await TestContainer.generateEmpty()
 
     // generateEmpty() is not empty: create_sites.sql seeds five fixture sites
-    // (ffvl_sid 1-5). Upserting Mocks.planpraz here used to collide with seeded
-    // ffvl_sid=1 on the unique `slug` constraint — which `on conflict(ffvl_sid)`
-    // does not cover — so the upsert silently failed and the assertion compared
-    // against a site that was never inserted.
+    // (ffvl_sid 1-5).
     //
     // Mocks.home sits ~0.8km from seeded ffvl_sid=4 (le-bois-du-bouchet) and
     // ~2km from plan-praz, so 4 is the correct nearest. getIdOfCloset returns

--- a/functions/src/model/database/Sites.ts
+++ b/functions/src/model/database/Sites.ts
@@ -10,28 +10,46 @@ export namespace Sites {
                 for await (const site of sites) {
                     console.log(`Upserting site=${JSON.stringify(site)}`)
                     try {
+                        // sites has two unique constraints: ffvl_sid (primary
+                        // key) and slug. Conflicts were only handled for
+                        // ffvl_sid, so a site whose slug was already held by a
+                        // *different* ffvl_sid raised sites_slug_key and was
+                        // dropped. That is reachable with real FFVL data: slug
+                        // is slugify(toponym), and slugify strips every
+                        // non-alphanumeric character, so two distinct sites
+                        // sharing a toponym — or differing only by accents or
+                        // punctuation — collapse to the same slug.
+                        //
+                        // Slug uniqueness has to hold: /sites/[site_slug]
+                        // resolves a site via Sites.getForSlug, so duplicates
+                        // would make that URL ambiguous. Instead the slug is
+                        // suffixed with the ffvl_sid when another site already
+                        // owns it. Deciding this inside the statement keeps it
+                        // atomic — a read-then-write would race — and the
+                        // whichever-site-got-there-first keeps the clean URL.
                         await database.query(`
                                     insert into sites(ffvl_sid, slug, name, lat, lng, alt, nearest_balise_id, polygon)
-                                    values ($1, $2, $3, $4, $5, $6, $7, $8)
+                                    values ($1,
+                                            case
+                                                when exists (select 1
+                                                             from sites
+                                                             where slug = $2
+                                                               and ffvl_sid <> $1)
+                                                    then $2 || '-' || $1
+                                                else $2
+                                                end,
+                                            $3, $4, $5, $6, $7, $8)
                                     on conflict(ffvl_sid)
-                                        do update set slug=$9,
-                                                      name=$10,
-                                                      lat=$11,
-                                                      lng=$12,
-                                                      alt=$13,
-                                                      nearest_balise_id=$14,
-                                                      polygon=$15
+                                        do update set slug=excluded.slug,
+                                                      name=excluded.name,
+                                                      lat=excluded.lat,
+                                                      lng=excluded.lng,
+                                                      alt=excluded.alt,
+                                                      nearest_balise_id=excluded.nearest_balise_id,
+                                                      polygon=excluded.polygon
                             `,
                             [
                                 site.ffvl_sid,
-                                site.slug,
-                                site.name,
-                                site.lat,
-                                site.lng,
-                                site.alt,
-                                site.nearest_balise_id,
-                                site.polygon,
-
                                 site.slug,
                                 site.name,
                                 site.lat,

--- a/functions/src/tasks/updateDescription/updateActivityDescription.test.ts
+++ b/functions/src/tasks/updateDescription/updateActivityDescription.test.ts
@@ -41,6 +41,14 @@ const AllDisabled: DescriptionPreference = {
     include_sites: false,
     include_all_time_aggregate: false
 }
+// With include_sites, appendSites joins flights.takeoff_id/landing_id against
+// sites.ffvl_sid. Every mock flight carries takeoff_id "456" and landing_id
+// "123" — Mocks.forclaz and Mocks.planpraz — so each expectation below is
+// prefixed with the same two lines. They were absent before only because those
+// two mock sites lost the slug collision in Sites.upsert and were never
+// inserted, so the join matched nothing. No aggregate figure changes.
+const siteLines = "↗️ Col de la Forclaz - Montmin\n↘️ Chamonix - Plan Praz - Brevent\n"
+
 const cases: [
     title: string,
     input: Input,
@@ -48,23 +56,25 @@ const cases: [
 ][] = [
 
     ["User 1 Activity 1", {flight: Mocks.user1activity1wing1, preference: AllEnabled},
-        "🪂 One 1 flight / 5min \n2025 1 flight / 5min\nAll Time 1 flight / 5min\n🌐 paragliderstats.com"],
+        siteLines + "🪂 One 1 flight / 5min \n2025 1 flight / 5min\nAll Time 1 flight / 5min\n🌐 paragliderstats.com"],
 
     // Spread AllEnabled, not AllDisabled. include_wind was already false in
     // AllDisabled, so this case was identical to the one below it — which
     // asserts null — while expecting full output. The expected string here is
     // AllEnabled minus the wind line, which is what this case is meant to cover.
+    // The mock sites have no nearest_balise_id, so no wind is appended either
+    // way; this case pins that turning include_wind off changes nothing else.
     ["User 1 Activity 1", {flight: Mocks.user1activity1wing1, preference: {...AllEnabled, include_wind: false}},
-        "🪂 One 1 flight / 5min \n2025 1 flight / 5min\nAll Time 1 flight / 5min\n🌐 paragliderstats.com"],
+        siteLines + "🪂 One 1 flight / 5min \n2025 1 flight / 5min\nAll Time 1 flight / 5min\n🌐 paragliderstats.com"],
 
     ["User 1 Activity 1", {flight: Mocks.user1activity1wing1, preference: AllDisabled},
         null],
 
     ["User 1 Activity 2", {flight: Mocks.user1activity2wing2, preference: AllEnabled},
-        "🪂 Two 1 flight / 1h 0min\n2025 2 flights / 1h 5min\nAll Time 2 flights / 1h 5min\n🌐 paragliderstats.com"],
+        siteLines + "🪂 Two 1 flight / 1h 0min\n2025 2 flights / 1h 5min\nAll Time 2 flights / 1h 5min\n🌐 paragliderstats.com"],
 
     ["User 1 Activity 3", {flight: Mocks.user1activity3wing1, preference: AllEnabled},
-        "🪂 One 2 flights / 15min\n2025 3 flights / 1h 15min\nAll Time 3 flights / 1h 15min\n🌐 paragliderstats.com"],
+        siteLines + "🪂 One 2 flights / 15min\n2025 3 flights / 1h 15min\nAll Time 3 flights / 1h 15min\n🌐 paragliderstats.com"],
 ]
 
 test.each(cases)('generateStats(%s)', async (_, input, expected) => {


### PR DESCRIPTION
## Problem

The `sites` table has **two** unique constraints — `ffvl_sid` (primary key) and `slug` — but `Sites.upsert` only handled conflicts on `ffvl_sid`:

```sql
on conflict(ffvl_sid) do update set ...
```

A site whose slug was already held by a *different* `ffvl_sid` raised `sites_slug_key`, got caught per-site, and failed the whole `SyncSites` task.

This is reachable with real FFVL data. `slug` is `slugify(toponym)`, and `slugify` strips every non-alphanumeric character, so two distinct sites sharing a toponym — or differing only by accents or punctuation, common in French place names — collapse to the same slug.

## Approach

Relaxing the constraint isn't an option: `/sites/[site_slug]` resolves a site through `Sites.getForSlug`, so a duplicate slug makes that URL ambiguous.

Instead the slug is suffixed with the `ffvl_sid` when another site already owns it, decided **inside the statement** so there's no check-then-write race:

```sql
values ($1,
        case when exists (select 1 from sites where slug = $2 and ffvl_sid <> $1)
             then $2 || '-' || $1
             else $2 end,
        ...)
on conflict(ffvl_sid) do update set slug = excluded.slug, ...
```

Whichever site got there first keeps the clean URL. Re-running the sync is idempotent — the suffix is derived, not appended each time.

`DO UPDATE` now uses `excluded.*` instead of repeating every value as `$9`–`$15`, removing a standing opportunity for the two parameter lists to drift.

## Scope

Fixed in both copies:
- `common/src/database/Sites.ts` — used by the site
- `functions/src/model/database/Sites.ts` — used by the live `SyncSites` task (`./syncSites` resolves to `syncSites.ts`, not `syncSites/index.ts`)

No database migration required; the constraint is unchanged.

## Test plan

- New regression test asserts the incumbent keeps the clean slug, the newcomer is suffixed, and a repeat upsert is idempotent.
- Description-formatter expectations were updated: the mock sites previously *failed* to insert because of this very bug, so `appendSites`' join on `flights.takeoff_id = sites.ffvl_sid` matched nothing. With the fix they resolve, and the generated descriptions now include takeoff/landing lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ya9DbiQmKouVXAinWtkRj