### PR TITLE
fix: Migrate domain from paragliderstats.com to ploufbag.com

### DIFF
--- a/common/src/DescriptionFormatter.ts
+++ b/common/src/DescriptionFormatter.ts
@@ -8,6 +8,7 @@ import {
 import { formatSiteName, formatAggregationResult } from './utils';
 import { Client } from './database';
 import { isSuccess, WindReport, WindDirection } from './model';
+import { DESCRIPTION_FOOTER } from './descriptionFooter';
 
 export interface PreferencesProvider {
     get(pilotId: StravaAthleteId): Promise<{ success: true; value: DescriptionPreference } | { success: false; error: string }>;
@@ -190,7 +191,7 @@ export class DescriptionFormatter {
             return null;
         }
 
-        return [...this.lines, '🌐 paragliderstats.com'].join('\n')
+        return [...this.lines, DESCRIPTION_FOOTER].join('\n')
     }
 
     // Standalone preview generation without database dependencies
@@ -251,6 +252,6 @@ export class DescriptionFormatter {
             return 'No preview available with current preferences';
         }
 
-        return [...lines, '🌐 paragliderstats.com'].join('\n');
+        return [...lines, DESCRIPTION_FOOTER].join('\n');
     }
 }

--- a/common/src/DescriptionFormatterClient.ts
+++ b/common/src/DescriptionFormatterClient.ts
@@ -4,6 +4,7 @@ import {
     SiteType 
 } from './types';
 import { formatSiteName, formatAggregationResult } from './utils';
+import { DESCRIPTION_FOOTER } from './descriptionFooter';
 
 // Client-side only version of DescriptionFormatter for previews
 export class DescriptionFormatterClient {
@@ -80,6 +81,6 @@ export class DescriptionFormatterClient {
             return 'No preview available with current preferences';
         }
 
-        return [...lines, '🌐 paragliderstats.com'].join('\n');
+        return [...lines, DESCRIPTION_FOOTER].join('\n');
     }
 }

--- a/common/src/descriptionFooter.test.ts
+++ b/common/src/descriptionFooter.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from "vitest";
+import {
+    DESCRIPTION_DOMAIN,
+    DESCRIPTION_FOOTER,
+    formattedStatsPattern,
+    isFormattedDescription,
+    LEGACY_DESCRIPTION_DOMAINS,
+} from "./descriptionFooter";
+
+// A realistic description as it appears on Strava after we have written to it:
+// pilot's own prose, then our stats block, then the footer.
+function describedFlight(domain: string): string {
+    return [
+        "Lovely evening at Saint-Hilaire",
+        "↗️ Saint Hilaire 12kmh/18kmh NW",
+        "↘️ Lumbin",
+        "🪂 Advance Epsilon  14 flights / 21h 30min",
+        "2026                31 flights / 48h 05min",
+        "All Time            87 flights / 124h 15min",
+        `🌐 ${domain}`,
+    ].join("\n");
+}
+
+const NEW_STATS = [
+    "↗️ Saint Hilaire 9kmh/14kmh N",
+    "↘️ Lumbin",
+    "🪂 Advance Epsilon  15 flights / 22h 30min",
+    `🌐 ${DESCRIPTION_DOMAIN}`,
+].join("\n");
+
+describe("isFormattedDescription", () => {
+    it("recognises a description stamped with the current domain", () => {
+        expect(isFormattedDescription(describedFlight(DESCRIPTION_DOMAIN))).toBe(true);
+    });
+
+    // The migration hazard: these are already published to Strava and must not be
+    // mistaken for unformatted, or updateDescription appends a second stats block.
+    it.each(LEGACY_DESCRIPTION_DOMAINS)("recognises the legacy domain %s", (legacyDomain) => {
+        expect(isFormattedDescription(describedFlight(legacyDomain))).toBe(true);
+    });
+
+    it("does not claim an untouched description is formatted", () => {
+        expect(isFormattedDescription("Lovely evening at Saint-Hilaire")).toBe(false);
+    });
+
+    it("does not match a description that merely mentions the domain in prose", () => {
+        expect(isFormattedDescription(`Stats are on ${DESCRIPTION_DOMAIN} by the way`)).toBe(false);
+    });
+});
+
+describe("formattedStatsPattern", () => {
+    it("replaces a current-domain stats block in place, leaving prose intact", () => {
+        const updated = describedFlight(DESCRIPTION_DOMAIN).replace(formattedStatsPattern(), NEW_STATS);
+
+        expect(updated).toBe(`Lovely evening at Saint-Hilaire\n${NEW_STATS}`);
+    });
+
+    // The core of the migration: an old-domain block must be replaced, not appended to.
+    it.each(LEGACY_DESCRIPTION_DOMAINS)("replaces a %s stats block in place", (legacyDomain) => {
+        const updated = describedFlight(legacyDomain).replace(formattedStatsPattern(), NEW_STATS);
+
+        expect(updated).toBe(`Lovely evening at Saint-Hilaire\n${NEW_STATS}`);
+        expect(updated).not.toContain(legacyDomain);
+    });
+
+    it("leaves exactly one footer after rewriting a legacy description", () => {
+        const updated = describedFlight(LEGACY_DESCRIPTION_DOMAINS[0]).replace(
+            formattedStatsPattern(),
+            NEW_STATS,
+        );
+
+        expect(updated.split("🌐").length - 1).toBe(1);
+        expect(updated).toContain(DESCRIPTION_FOOTER);
+    });
+
+    it("is greedy enough to consume a block spanning takeoff through footer", () => {
+        // The block starts at the first stats glyph (↗️ here, not 🪂), so a partial
+        // match would strip the aggregates while orphaning the site lines.
+        const updated = describedFlight(DESCRIPTION_DOMAIN).replace(formattedStatsPattern(), "");
+
+        expect(updated).toBe("Lovely evening at Saint-Hilaire\n");
+    });
+
+    it("returns a fresh regex each call so lastIndex is never carried over", () => {
+        expect(formattedStatsPattern()).not.toBe(formattedStatsPattern());
+    });
+});

--- a/common/src/descriptionFooter.ts
+++ b/common/src/descriptionFooter.ts
@@ -1,0 +1,57 @@
+/**
+ * The footer stamped onto every Strava activity description we write, and the
+ * matchers used to recognise a description we have already written.
+ *
+ * These live together because the write side and the read side have to agree
+ * exactly. They were previously three copies of a bare string literal plus two
+ * hand-rolled regexes, which is precisely the shape that breaks during a domain
+ * migration: the writer moves to the new domain while the matcher keeps looking
+ * for the old one.
+ */
+
+/** Domain shown in the footer of newly written descriptions. */
+export const DESCRIPTION_DOMAIN = 'ploufbag.com';
+
+/**
+ * Domains we used to stamp. Descriptions already published to Strava still carry
+ * these, so the matchers below must keep recognising them.
+ *
+ * Remove an entry only once every activity bearing it has been rewritten by a
+ * full re-sync — until then, dropping it makes those activities read as
+ * unformatted, and `updateDescription` responds to "unformatted" by *appending*
+ * a stats block rather than replacing one. The visible symptom is an activity
+ * with two stats blocks, and it is not self-healing.
+ */
+export const LEGACY_DESCRIPTION_DOMAINS = ['paragliderstats.com'] as const;
+
+export const DESCRIPTION_FOOTER = `🌐 ${DESCRIPTION_DOMAIN}`;
+
+const ALL_DESCRIPTION_DOMAINS = [DESCRIPTION_DOMAIN, ...LEGACY_DESCRIPTION_DOMAINS];
+
+/** Alternation of every domain we have ever stamped, dots escaped. */
+const DOMAIN_ALTERNATION = ALL_DESCRIPTION_DOMAINS
+    .map(domain => domain.replace(/\./g, '\\.'))
+    .join('|');
+
+/**
+ * Matches an existing stats block: from the first stats glyph through to the
+ * footer domain.
+ *
+ * The character class is carried over verbatim from the original expression.
+ * These glyphs are not single UTF-16 code units — 🪂 is a surrogate pair and
+ * ↗️/↘️ are a base arrow plus U+FE0F — so without the `u` flag the class matches
+ * their constituent units rather than the glyphs as such. That is loose, but it
+ * is the behaviour that has been matching real descriptions in production, and a
+ * domain migration is the wrong moment to also tighten it.
+ */
+export function formattedStatsPattern(): RegExp {
+    return new RegExp(`[🪂↗️↘️][\\s\\S]*(?:${DOMAIN_ALTERNATION})`);
+}
+
+/**
+ * True when this description already carries a stats block we wrote, under the
+ * current domain or any legacy one.
+ */
+export function isFormattedDescription(description: string): boolean {
+    return ALL_DESCRIPTION_DOMAINS.some(domain => description.includes(`🌐 ${domain}`));
+}

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,5 +1,6 @@
 export * from './database';
 export * from './utils';
+export * from './descriptionFooter';
 export * from './DescriptionFormatter';
 export * from './DescriptionFormatterClient';
 export * from './model';

--- a/compose.yaml
+++ b/compose.yaml
@@ -65,6 +65,8 @@ services:
       - DATABASE_USER=${LOCAL_DATABASE_USER}
       - DATABASE_PASSWORD=${LOCAL_DATABASE_PASSWORD}
       - DATABASE_NAME=${LOCAL_DATABASE_NAME}
+      - COOKIE_DOMAIN=${COOKIE_DOMAIN}
+      - SITE_URL=${SITE_URL}
     volumes:
       - ./functions/src:/app/src
     expose:

--- a/functions/requests/http-client.env.json
+++ b/functions/requests/http-client.env.json
@@ -1,8 +1,8 @@
 {
   "prod": {
     "strava_api_url": "https://www.strava.com/api/v3",
-    "parastats_api_base_url": "https://api.paragliderstats.com",
-    "parastats_tasks_base_url": "https://tasks.paragliderstats.com"
+    "parastats_api_base_url": "https://api.ploufbag.com",
+    "parastats_tasks_base_url": "https://tasks.ploufbag.com"
   },
   "local": {
     "strava_api_url": "https://www.strava.com/api/v3",

--- a/functions/src/jwt.ts
+++ b/functions/src/jwt.ts
@@ -16,8 +16,17 @@ export function sign(userId: number, res: Response): string {
     console.log(`sign process.env.SESSION_SECRET=${process.env.SESSION_SECRET}`)
 
     const jwtToken = generateJwt(userId)
+
+    // Scoped to the apex domain, not the subdomain that sets it: this runs on
+    // webhooks.<domain> but the cookie has to be readable by the site on the apex.
+    //
+    // Empty/unset means omit the Domain attribute entirely, producing a host-only
+    // cookie. That is required for localhost, which browsers refuse to accept as a
+    // Domain value — passing domain: "" to res.cookie would send `Domain=`, so the
+    // property has to be absent rather than blank.
+    const cookieDomain = process.env.COOKIE_DOMAIN;
     res.cookie('sid', jwtToken, {
-        domain: "paragliderstats.com",
+        ...(cookieDomain ? {domain: cookieDomain} : {}),
         httpOnly: false,
         secure: true,
         sameSite: 'lax',

--- a/functions/src/model/database/Mocks.test.ts
+++ b/functions/src/model/database/Mocks.test.ts
@@ -79,7 +79,7 @@ export namespace Mocks {
         wing: "One",
         duration_sec: 10 * 60,
         ...flightFiller(),
-        description: "Some description\n🪂 One\nThis wing Xmin over Y flights\nThis year 1h 15min over 3 flights\nAll time 1h 15min over 3 flights\n🌐 paragliderstats.com",
+        description: "Some description\n🪂 One\nThis wing Xmin over Y flights\nThis year 1h 15min over 3 flights\nAll time 1h 15min over 3 flights\n🌐 ploufbag.com",
     }
     export const user1activity4wing1: FlightRow = {
         pilot_id: userRow1.pilot_id,

--- a/functions/src/tasks/updateDescription.ts
+++ b/functions/src/tasks/updateDescription.ts
@@ -1,4 +1,12 @@
-import {isSuccess, UpdateDescriptionTask, TaskResult, StravaActivityId, FlightRow} from "@parastats/common";
+import {
+    isSuccess,
+    UpdateDescriptionTask,
+    TaskResult,
+    StravaActivityId,
+    FlightRow,
+    isFormattedDescription,
+    formattedStatsPattern
+} from "@parastats/common";
 import {Pilots} from '@/database/Pilots';
 import {Flights} from '@/database/Flights';
 import {StravaApi} from '@/stravaApi';
@@ -34,14 +42,17 @@ export async function executeUpdateDescriptionTask(
         };
     }
 
-    // Check if description is already formatted
-    const alreadyFormatted = flight.description.includes("🌐 paragliderstats.com");
+    // Check if description is already formatted. Recognises legacy domains as well
+    // as the current one — activities published before the ploufbag.com migration
+    // still carry the old footer, and misreading those as unformatted would send
+    // them down the append path below and give them a second stats block.
+    const alreadyFormatted = isFormattedDescription(flight.description);
 
     // Generate the new description
     let updatedDescription: string;
     if (alreadyFormatted) {
         console.log("Updating existing formatted description");
-        updatedDescription = flight.description.replace(/(?:[🪂↘️↗️])[\s\S]*paragliderstats.com/, newStats);
+        updatedDescription = flight.description.replace(formattedStatsPattern(), newStats);
     } else {
         console.log("Appending stats to description");
         updatedDescription = flight.description.replace(`🪂 ${flight.wing}`, newStats);

--- a/functions/src/tasks/updateDescription/DescriptionFormatter.ts
+++ b/functions/src/tasks/updateDescription/DescriptionFormatter.ts
@@ -1,4 +1,4 @@
-import {DescriptionPreference, FlightRow, isSuccess, SiteType, WindDirection} from "@parastats/common";
+import {DESCRIPTION_FOOTER, DescriptionPreference, FlightRow, isSuccess, SiteType, WindDirection} from "@parastats/common";
 import {withPooledClient, Client} from "@parastats/common";
 import {FFVL} from "@/ffvlApi";
 import {DescriptionPreferences} from "@parastats/common";
@@ -173,7 +173,7 @@ export class DescriptionFormatter {
                 return null;
             }
 
-            return [...this.lines, '🌐 paragliderstats.com'].join('\n')
+            return [...this.lines, DESCRIPTION_FOOTER].join('\n')
         });
     }
 }

--- a/functions/src/tasks/updateDescription/index.ts
+++ b/functions/src/tasks/updateDescription/index.ts
@@ -1,5 +1,5 @@
 import {TaskResult, TaskBody} from "@/tasks/model";
-import {Pilots, Flights, isSuccess} from "@parastats/common";
+import {Pilots, Flights, isSuccess, isFormattedDescription, formattedStatsPattern} from "@parastats/common";
 import {StravaApi} from "@/stravaApi";
 import {StravaActivityId} from "@/stravaApi/model";
 import {generateStats} from "./updateActivityDescription";
@@ -44,13 +44,13 @@ export default async function (task: TaskBody): Promise<TaskResult> {
     }
 
     // Check description is already winged
-    const alreadyWinged = activityRow.description.includes("🌐 paragliderstats.com")
+    const alreadyWinged = isFormattedDescription(activityRow.description)
 
     // If winged, replace stats
     let wingedDescription: string
     if (alreadyWinged) {
         console.log("Updating")
-        wingedDescription = activityRow.description.replace(/[🪂↗️↘️][\s\S]*paragliderstats.com/, stats)
+        wingedDescription = activityRow.description.replace(formattedStatsPattern(), stats)
     } else {
         console.log("Appending")
         wingedDescription = activityRow.description.replace(`🪂 ${activityRow.wing}`, stats)

--- a/functions/src/tasks/updateDescription/updateActivityDescription.test.ts
+++ b/functions/src/tasks/updateDescription/updateActivityDescription.test.ts
@@ -56,7 +56,7 @@ const cases: [
 ][] = [
 
     ["User 1 Activity 1", {flight: Mocks.user1activity1wing1, preference: AllEnabled},
-        siteLines + "🪂 One 1 flight / 5min \n2025 1 flight / 5min\nAll Time 1 flight / 5min\n🌐 paragliderstats.com"],
+        siteLines + "🪂 One 1 flight / 5min \n2025 1 flight / 5min\nAll Time 1 flight / 5min\n🌐 ploufbag.com"],
 
     // Spread AllEnabled, not AllDisabled. include_wind was already false in
     // AllDisabled, so this case was identical to the one below it — which
@@ -65,16 +65,16 @@ const cases: [
     // The mock sites have no nearest_balise_id, so no wind is appended either
     // way; this case pins that turning include_wind off changes nothing else.
     ["User 1 Activity 1", {flight: Mocks.user1activity1wing1, preference: {...AllEnabled, include_wind: false}},
-        siteLines + "🪂 One 1 flight / 5min \n2025 1 flight / 5min\nAll Time 1 flight / 5min\n🌐 paragliderstats.com"],
+        siteLines + "🪂 One 1 flight / 5min \n2025 1 flight / 5min\nAll Time 1 flight / 5min\n🌐 ploufbag.com"],
 
     ["User 1 Activity 1", {flight: Mocks.user1activity1wing1, preference: AllDisabled},
         null],
 
     ["User 1 Activity 2", {flight: Mocks.user1activity2wing2, preference: AllEnabled},
-        siteLines + "🪂 Two 1 flight / 1h 0min\n2025 2 flights / 1h 5min\nAll Time 2 flights / 1h 5min\n🌐 paragliderstats.com"],
+        siteLines + "🪂 Two 1 flight / 1h 0min\n2025 2 flights / 1h 5min\nAll Time 2 flights / 1h 5min\n🌐 ploufbag.com"],
 
     ["User 1 Activity 3", {flight: Mocks.user1activity3wing1, preference: AllEnabled},
-        siteLines + "🪂 One 2 flights / 15min\n2025 3 flights / 1h 15min\nAll Time 3 flights / 1h 15min\n🌐 paragliderstats.com"],
+        siteLines + "🪂 One 2 flights / 15min\n2025 3 flights / 1h 15min\nAll Time 3 flights / 1h 15min\n🌐 ploufbag.com"],
 ]
 
 test.each(cases)('generateStats(%s)', async (_, input, expected) => {

--- a/functions/src/webhooks/handleCode.ts
+++ b/functions/src/webhooks/handleCode.ts
@@ -62,5 +62,5 @@ export async function handleCode(req: Request, res: Response) {
 
     sign(athlete.id, res)
 
-    res.redirect('https://paragliderstats.com/welcome');
+    res.redirect(`${process.env.SITE_URL}/welcome`);
 }

--- a/infra/dns.tf
+++ b/infra/dns.tf
@@ -1,25 +1,75 @@
-resource "google_dns_managed_zone" "paragliderstats" {
-  name          = "parastats-info"
+# The zone is named after the domain it serves, but the resource label is not:
+# `dns_name` is ForceNew, so a domain change is always a destroy-and-create. Keeping
+# the label domain-neutral means the next migration is a one-line edit to local.domain
+# rather than a rename that churns every reference in this file.
+#
+# The zone `name` deliberately differs from the previous zone's ("parastats-info").
+# Managed-zone names are unique per project and Terraform does not guarantee it
+# destroys the old zone before creating the new one; reusing the name risks the
+# create colliding with a zone that has not been torn down yet.
+resource "google_dns_managed_zone" "primary" {
+  name          = "ploufbag-com"
   dns_name      = "${local.domain}."
   description   = local.domain
   force_destroy = "true"
 }
 
-# resource "google_dns_record_set" "default" {
-#   name         = google_dns_managed_zone.parastats.dns_name
-#   managed_zone = google_dns_managed_zone.parastats.name
-#   type         = "A"
-#   ttl          = 300
-#   rrdatas = [
-#     google_storage_bucket.site.url
-#   ]
-# }
+# Google's fixed anycast addresses for Cloud Run / App Engine custom domains. These
+# are not per-project or per-service values and do not change; the domain mapping
+# routes on the Host header once traffic arrives.
+locals {
+  ghs_ipv4 = [
+    "216.239.32.21",
+    "216.239.34.21",
+    "216.239.36.21",
+    "216.239.38.21",
+  ]
+  ghs_ipv6 = [
+    "2001:4860:4802:32::15",
+    "2001:4860:4802:34::15",
+    "2001:4860:4802:36::15",
+    "2001:4860:4802:38::15",
+  ]
 
+  # Every subdomain fronted by a Cloud Run domain mapping. Keep in step with the
+  # google_cloud_run_domain_mapping resources in function.*.tf.
+  service_subdomains = ["api", "tasks", "webhooks"]
+}
 
-# resource "google_dns_record_set" "functions" {
-#   name         = "functions.${google_dns_managed_zone.parastats.dns_name}"
-#   managed_zone = google_dns_managed_zone.parastats.name
-#   type         = "CNAME"
-#   ttl          = 300
-#   rrdatas = ["parastats-functions-g5cggejw3q-ue.a.run.app"]
-# }
+# The apex cannot be a CNAME (RFC 1034 forbids a CNAME coexisting with the zone's
+# own SOA and NS records), so the site is reached via A/AAAA to the ghs addresses
+# rather than the ghs.googlehosted.com. alias used for the subdomains below.
+resource "google_dns_record_set" "apex_ipv4" {
+  name         = google_dns_managed_zone.primary.dns_name
+  managed_zone = google_dns_managed_zone.primary.name
+  type         = "A"
+  ttl          = 300
+  rrdatas      = local.ghs_ipv4
+}
+
+resource "google_dns_record_set" "apex_ipv6" {
+  name         = google_dns_managed_zone.primary.dns_name
+  managed_zone = google_dns_managed_zone.primary.name
+  type         = "AAAA"
+  ttl          = 300
+  rrdatas      = local.ghs_ipv6
+}
+
+resource "google_dns_record_set" "services" {
+  for_each = toset(local.service_subdomains)
+
+  name         = "${each.key}.${google_dns_managed_zone.primary.dns_name}"
+  managed_zone = google_dns_managed_zone.primary.name
+  type         = "CNAME"
+  ttl          = 300
+  rrdatas      = ["ghs.googlehosted.com."]
+}
+
+# Surfaced so the delegation can be copied into the registrar. The nameservers are
+# assigned by Google at zone-create time and differ from the destroyed zone's, so
+# Namecheap must be repointed at these values before the domain mappings can
+# finish provisioning their managed certificates.
+output "dns_name_servers" {
+  description = "Set these as the nameservers for the primary domain at the registrar."
+  value       = google_dns_managed_zone.primary.name_servers
+}

--- a/infra/main.outputs.tf
+++ b/infra/main.outputs.tf
@@ -1,25 +1,33 @@
 locals {
   functions_variables = {
-    SESSION_SECRET            = random_id.session_secret.b64_std
-    INSTANCE_CONNECTION_NAME  = google_sql_database_instance.instance.connection_name
-    DATABASE_HOST             = google_sql_database_instance.instance.public_ip_address
-    DATABASE_NAME             = google_sql_database.database.name
-    DATABASE_PORT             = 5432
-    DATABASE_USER             = google_sql_user.functions.name
-    DATABASE_PASSWORD         = random_password.database.result
+    SESSION_SECRET                  = random_id.session_secret.b64_std
+    INSTANCE_CONNECTION_NAME        = google_sql_database_instance.instance.connection_name
+    DATABASE_HOST                   = google_sql_database_instance.instance.public_ip_address
+    DATABASE_NAME                   = google_sql_database.database.name
+    DATABASE_PORT                   = 5432
+    DATABASE_USER                   = google_sql_user.functions.name
+    DATABASE_PASSWORD               = random_password.database.result
     CLIENT_ID                       = var.client_id
     CLIENT_SECRET                   = var.client_secret
     QUEUE_ID_FETCH_ACTIVITIES       = google_cloud_tasks_queue.fetch_activities.id
     QUEUE_ID_WING_ACTIVITY          = google_cloud_tasks_queue.wing_activity.id
     QUEUE_ID_UPDATE_SINGLE_ACTIVITY = google_cloud_tasks_queue.update_single_activity.id
     TASKS_URL                       = "https://tasks.${local.domain}"
-    API_URL                   = "https://api.${local.domain}"
-    SITE_PORT                 = 80
-    TASKS_PORT                = 3000
-    WEBHOOKS_PORT             = 4000
-    API_PORT                  = 81
-    FFVL_KEY                  = var.ffvl_key
-    NEXT_PUBLIC_MAPBOX_TOKEN  = var.mapbox_token
+    API_URL                         = "https://api.${local.domain}"
+
+    # The session cookie is set by the webhooks service on webhooks.<domain> but has
+    # to be readable by the site on the apex, so it is scoped to the apex rather than
+    # the subdomain that sets it. SITE_URL is where OAuth hands the browser back.
+    # Both were previously hardcoded to the old domain in functions/src/jwt.ts and
+    # functions/src/webhooks/handleCode.ts.
+    COOKIE_DOMAIN            = local.domain
+    SITE_URL                 = "https://${local.domain}"
+    SITE_PORT                = 80
+    TASKS_PORT               = 3000
+    WEBHOOKS_PORT            = 4000
+    API_PORT                 = 81
+    FFVL_KEY                 = var.ffvl_key
+    NEXT_PUBLIC_MAPBOX_TOKEN = var.mapbox_token
   }
   compose_variables = {
     SESSION_SECRET              = random_id.session_secret.b64_std
@@ -40,15 +48,21 @@ locals {
     WEBHOOKS_PORT               = 4000
     API_PORT                    = 81
     API_URL                     = "http://api:81"
-    DEBUG                       = 1
-    FFVL_KEY                    = var.ffvl_key
+
+    # Cookies on localhost must be set with no Domain attribute at all — a literal
+    # "localhost" is rejected by browsers as a domain scope. jwt.ts treats an empty
+    # COOKIE_DOMAIN as "host-only cookie", which is the correct local behaviour.
+    COOKIE_DOMAIN = ""
+    SITE_URL      = "http://localhost"
+    DEBUG         = 1
+    FFVL_KEY      = var.ffvl_key
   }
 }
 
 
 resource "local_file" "functions_envs" {
   content = join("\n", flatten([
-    for key, value in local.functions_variables :[
+    for key, value in local.functions_variables : [
       "${key}=${value}"
     ]
   ]))
@@ -57,7 +71,7 @@ resource "local_file" "functions_envs" {
 
 resource "local_file" "compose_envs" {
   content = join("\n", flatten([
-    for key, value in local.compose_variables :[
+    for key, value in local.compose_variables : [
       "${key}=${value}"
     ]
   ]))

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,7 +1,7 @@
 locals {
   project_id = "para-stats"
   region     = "europe-west1"
-  domain     = "paragliderstats.com"
+  domain     = "ploufbag.com"
 }
 
 provider "google" {

--- a/scripts/src/registerWebhook.ts
+++ b/scripts/src/registerWebhook.ts
@@ -14,7 +14,7 @@ interface WebhookSubscription {
 async function registerWebhook() {
     const clientId = process.env.STRAVA_CLIENT_ID;
     const clientSecret = process.env.STRAVA_CLIENT_SECRET;
-    const callbackUrl = process.env.WEBHOOK_CALLBACK_URL || 'https://webhooks.paragliderstats.com';
+    const callbackUrl = process.env.WEBHOOK_CALLBACK_URL || 'https://webhooks.ploufbag.com';
     const verifyToken = process.env.STRAVA_WEBHOOK_VERIFY_TOKEN;
 
     if (!clientId || !clientSecret || !verifyToken) {
@@ -163,7 +163,7 @@ const command = process.argv[2];
                 console.log("  STRAVA_CLIENT_ID");
                 console.log("  STRAVA_CLIENT_SECRET");
                 console.log("  STRAVA_WEBHOOK_VERIFY_TOKEN");
-                console.log("  WEBHOOK_CALLBACK_URL (optional, defaults to https://webhooks.paragliderstats.com)");
+                console.log("  WEBHOOK_CALLBACK_URL (optional, defaults to https://webhooks.ploufbag.com)");
                 process.exit(1);
         }
     } catch (error) {

--- a/site/src/app/login/page.tsx
+++ b/site/src/app/login/page.tsx
@@ -109,7 +109,7 @@ export default function Login() {
 
             <div style={{ marginBottom: 'var(--space-6)' }}>
                 <a className={styles.stravaButton}
-                   href="https://www.strava.com/oauth/authorize?client_id=155420&redirect_uri=https%3A%2F%2Fwebhooks.paragliderstats.com&response_type=code&approval_prompt=force&scope=read_all,activity:write,activity:read_all">
+                   href="https://www.strava.com/oauth/authorize?client_id=155420&redirect_uri=https%3A%2F%2Fwebhooks.ploufbag.com&response_type=code&approval_prompt=force&scope=read_all,activity:write,activity:read_all">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.599h4.172L10.463 0l-7 13.828h4.172"/>
                     </svg>

--- a/site/src/app/styleguide/page.tsx
+++ b/site/src/app/styleguide/page.tsx
@@ -7,7 +7,7 @@ export default function StyleGuidePage() {
     <div className={styles.styleguide}>
       <header className={styles.header}>
         <h1>Parastats Design System</h1>
-        <p>Living style guide for paragliderstats.com</p>
+        <p>Living style guide for ploufbag.com</p>
       </header>
 
       {/* Table of Contents */}


### PR DESCRIPTION
## Why

`paragliderstats.com` is gone — it currently resolves to **no nameservers at all**, so every
Cloud Run domain mapping (site, api, tasks, webhooks) is dead and the service is fully down.
`ploufbag.com` has been purchased (Namecheap, expires 2027-08-15) and replaces it.

Because the old domain is unrecoverable there is no overlap window to preserve: no redirects,
no dual-domain serving, no zero-downtime cutover. This is a restore-service migration.

## Scope

**Domain only.** The user-facing name ("Paraglider Stats") and the `@parastats/*` package scope
are deliberately untouched — rebranding follows in a separate PR.

## Prerequisites (done out of band)

- [x] `ploufbag.com` verified in Google Search Console under the `para-stats` project owner
- [x] Strava API app (client_id `155420`) Authorization Callback Domain updated to `ploufbag.com`

## What changed

### `refactor: Centralise the Strava description footer and its matchers`

The footer was three copies of a string literal; the "have we already written this description"
check was two separately hand-rolled regexes. That is the shape that breaks under a domain
migration — the writer moves while the matcher keeps looking for the old domain.

The failure mode is worse than a missed update. `updateDescription` treats *not formatted* as
*append a stats block*, so a matcher that stops recognising the old domain gives every
previously-published activity a **second** stats block, and it does not self-heal.

Matchers now accept a list of legacy domains alongside the current one, in one place.
`LEGACY_DESCRIPTION_DOMAINS` is the single spot to narrow once the back catalogue is re-synced.

Covered by 9 new unit tests, including the "legacy description ends up with exactly one footer"
case that is the whole point of the exercise.

### `fix: Point application code at ploufbag.com`

Two references became environment-driven rather than re-hardcoded, since they differ between
production and local dev:

- **Session cookie domain** — stays scoped to the **apex**, not the `webhooks` subdomain that
  sets it, because the site on the apex has to read it. An empty `COOKIE_DOMAIN` omits the
  `Domain` attribute entirely (host-only cookie), which is required for localhost — browsers
  reject `localhost` as a `Domain` value, and `domain: ""` would emit a bare `Domain=`.
- **Post-OAuth redirect** — now `SITE_URL`.

The rest are literal replacements: login page OAuth `redirect_uri`, webhook registration
default, style guide copy, HTTP-client dev env, test fixtures.

### `fix: Migrate infrastructure to ploufbag.com and manage DNS records`

`local.domain` drives all four domain mappings plus `TASKS_URL`/`API_URL`, so the domain itself
is one line. The zone is *replaced* (`dns_name` is ForceNew) and given a **different zone name**
from the old one — managed-zone names are unique per project and Terraform does not guarantee
destroy-before-create, so reusing the name risks colliding with a zone not yet torn down.

The record sets were commented out **and referenced a resource address that never existed**
(`google_dns_managed_zone.parastats` vs the actual `.paragliderstats`), meaning live records
were maintained by hand. Since the zone is being rebuilt anyway they are now under Terraform:
A+AAAA on the apex (an apex cannot be a CNAME) and CNAMEs to `ghs.googlehosted.com.` for the
service subdomains. Nameservers are exposed as an output for copying to the registrar.

## Verified plan

```
google_cloud_run_domain_mapping.{api,site,tasks,webhooks}  must be replaced
google_dns_managed_zone.paragliderstats                    will be destroyed
google_dns_managed_zone.primary                            will be created
google_dns_record_set.{apex_ipv4,apex_ipv6}                will be created
google_dns_record_set.services["api"|"tasks"|"webhooks"]   will be created
google_cloudfunctions2_function.{api,tasks,webhooks}       updated in-place
google_cloud_run_v2_service.site                           updated in-place

Plan: 13 to add, 4 to change, 6 to destroy.
```

No database, bucket, or queue is touched.

## Cutover ordering (load-bearing — do not run a single apply)

Replacing the mappings restarts managed-certificate provisioning, which hangs indefinitely if
DNS does not resolve (see the existing comments in `site.tf`).

1. `terraform apply -target=google_dns_managed_zone.primary` → read `dns_name_servers`
2. Set those four nameservers on `ploufbag.com` at Namecheap; wait for `dig NS ploufbag.com`
3. Full `terraform apply` → mappings created, certificates provision against live DNS
4. Rebuild + deploy the site image (the OAuth `redirect_uri` is inlined at build time → new `site_tag`)
5. Re-register the Strava webhook against `https://webhooks.ploufbag.com` — **after** the cert is
   live, since Strava validates the callback with a GET challenge at subscription time
6. Backfill descriptions, then drop `paragliderstats.com` from `LEGACY_DESCRIPTION_DOMAINS`

## Test plan

- [x] `cd common && yarn test` — 9 passed (all new)
- [x] `cd common && yarn build` — clean
- [x] `cd functions && npx tsc --noEmit` — clean
- [x] `cd infra && terraform validate` — valid
- [x] `cd infra && terraform plan` — reviewed, output above
- [x] `cd functions && yarn test` — **24 passed / 3 skipped in CI**. Could not run locally: no
      container runtime on this machine (Docker CLI present, no daemon), so all 7 Testcontainers
      suites failed at `beforeAll` with `Could not find a working container runtime strategy` —
      identically before and after these changes, verified by stashing. CI has Docker and runs
      them for real, including the `updateActivityDescription` suite edited here.
- [x] `cd site && yarn build` — **passes in CI**. Fails locally, but fails identically on
      unmodified `main` (`_global-error` prerender, `TypeError: Cannot read properties of null
      (reading 'useContext')`, digest `1873134106`). Machine-specific and pre-existing.
- [ ] `task local-build && docker compose up` — **not run**: blocked by the same missing
      container runtime. Not covered by CI either, so the local compose path is genuinely
      unverified by this PR.

### CI result

| Check | Result |
|---|---|
| `common (test + build)` | pass — 9 passed |
| `functions (test)` | pass — 24 passed / 3 skipped |
| `site (build)` | pass |
| `terraform (fmt + validate)` | pass |
| `Plan` | pass |
| `claude-review` | **fail — `Credit balance is too low`** (Action billing, unrelated to this diff) |

## Notes for review

- `common/dist/index.{js,d.ts}` are tracked despite `/common/dist/` being gitignored. They are
  stale leftovers — both CI and deploy rebuild `common` from source, so nothing consumes them.
  Deliberately left at `HEAD` rather than committed: a regenerated `index.js` would `require`
  an untracked `./descriptionFooter`. Worth untracking separately.
- The `webhooks` service in `compose.yaml` has no `SESSION_SECRET`/`CLIENT_ID`/`CLIENT_SECRET`,
  so the OAuth callback cannot run locally regardless of this change. Pre-existing; not fixed
  here to keep the diff to the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ya9DbiQmKouVXAinWtkRj

---

<details>
<summary>Conversation History</summary>

### 1. User

> I no longer have paragliderstats.com and must change to ploufbag.com that I just purchased. Make a migration plan

### 1. Claude

Swept the repo for every `paragliderstats` reference and read the Terraform, then checked live DNS
for both domains. Found that `paragliderstats.com` has **no nameservers at all** — the service was
already fully down — and that `ploufbag.com` sits on Namecheap's default DNS behind a parking page.

Reported that the infra was already well-parameterised (`local.domain` feeds all four domain
mappings plus `TASKS_URL`/`API_URL`), so the real work was ~15 hardcoded literals plus three
external systems Terraform can't reach.

Flagged three gotchas:

1. **Existing Strava descriptions would get mangled.** `updateDescription` detects prior formatting
   by searching for the literal `🌐 paragliderstats.com`. Flipping it outright sends every
   already-published activity down the *append* branch, giving it a second stats block.
2. **Cloud Run domain mappings are ForceNew on `name`** — the change replaces all four and restarts
   cert provisioning, which hangs if DNS doesn't resolve.
3. **Google Search Console verification is a prerequisite** for creating any mapping.

Delivered a phased plan (external prereqs → infra → application → webhook re-registration →
backfill) and surfaced two decisions: Cloud DNS vs Namecheap DNS, and domain-only vs full rebrand.

### 2. User

> I have done both steps of Phase 0
> - Stick to Cloud DNS
> - Let's first make the DNS change operational, then apply the rebrand

### 2. Claude

Created `fix/migrate-domain-ploufbag` and draft PR #22 before touching code, per the guardrails.

**Infra:** flipped `local.domain`; rebuilt the DNS zone with a domain-neutral resource label and a
*different* zone name (managed-zone names are unique per project and Terraform doesn't guarantee
destroy-before-create); brought the record sets under Terraform — they had been commented out *and*
referenced a resource address that never existed, so live records were being hand-maintained. Added
A+AAAA on the apex (an apex can't be a CNAME) and CNAMEs for the service subdomains, plus a
nameserver output. Added `COOKIE_DOMAIN`/`SITE_URL` to both variable sets.

**Application:** made the cookie domain and OAuth redirect environment-driven rather than
re-hardcoded. Kept the cookie on the apex (the site must read what the `webhooks` subdomain sets)
and made an empty `COOKIE_DOMAIN` omit the `Domain` attribute entirely, since browsers reject
`localhost` as a `Domain` value.

**The subtle fix:** centralised the footer and its matchers in a new `common/src/descriptionFooter.ts`
with a `LEGACY_DESCRIPTION_DOMAINS` list, so activities published under the old domain are still
recognised and *replaced* rather than appended to. Carried the emoji character class over verbatim
rather than tidying it — those glyphs aren't single UTF-16 code units, and a domain migration is the
wrong moment to also change matching behaviour. Covered with 9 unit tests.

**Verification:** `terraform validate` and `plan` clean (plan reviewed above). Discovered this
machine has the Docker CLI but no daemon, so the Testcontainers suites and `docker compose` can't
run locally; confirmed the local `site build` failure reproduces identically on unmodified `main`
before attributing it to the environment. Delegated both to CI, which passed them
(24 tests / 3 skipped, site build green).

Left `common/dist/index.{js,d.ts}` at `HEAD` rather than committing regenerated output that would
`require` an untracked sibling.

### 3. User

Chose **review and merge before applying** any Terraform.

### 3. Claude

Marked this PR ready for review. No `terraform apply` has been run — the cutover destroys the live
DNS zone, and step 2 requires setting nameservers at Namecheap by hand.

</details>

---

## Cutover status (live, 2026-08-15)

Steps 1–3 and 5 of the runbook are **done and verified against production**:

| Step | Status | Evidence |
|---|---|---|
| NS delegation → Cloud DNS | done | four `ns-cloud-d*.googledomains.com` authoritative |
| DNS records | done | apex `A`+`AAAA` → 4 ghs v4/v6; `api`/`tasks`/`webhooks` → `ghs.googlehosted.com.` |
| Old `paragliderstats` zone | destroyed | `Apply complete! 12 added, 4 changed, 6 destroyed` |
| Domain mappings | done | all four created, certs issued by Google Trust Services (WR3), valid to 13 Nov 2026 |
| Functions deployed | done | `jwt.js` reads `COOKIE_DOMAIN`; `handleCode.js` reads `SITE_URL` |
| Strava webhook | done | old sub `323087` deleted (`204`); new sub **`365986`** → `https://webhooks.ploufbag.com` (`201`) |

Live responses: apex `200` (app renders, `<title>Paraglider Stats</title>`), `api` `401`
(unauthenticated GET — correct), `tasks` `400` (expects POST body — correct), `webhooks` `200`
and echoing `hub.challenge` correctly.

### Two things caught during cutover, worth knowing

**`terraform apply` deploys whatever is sitting in `functions/dist`.** `data "archive_file"`
reads it from disk with no dependency edge back to the TypeScript build, so the first apply
shipped four-hour-old JavaScript — new env vars, old code, with `paragliderstats.com` still
hardcoded in `jwt.js`. `terraform plan` looked clean throughout. Fixed by `yarn buildProd` and a
second apply. `deploy.yml` already guards against this; a manual apply does not.

**The Cloud Run mapping status field is not a reliable readiness signal.** It reported `True`
for three mappings while no host would complete a TLS handshake, and `webhooks` flapped back to
`CertificatePending` *after* reporting ready — yet was the first to actually serve. Curling the
endpoint is the honest test.

### Still outstanding

- [ ] **Merge this PR.** The site image inlines the Strava OAuth `redirect_uri` at build time, so
      `https://ploufbag.com/login` still emits `redirect_uri=...webhooks.paragliderstats.com` and
      **OAuth login is broken until a rebuild ships**. Merging triggers `deploy.yml`, which builds
      the image tagged with the commit SHA and passes it as `TF_VAR_site_tag` — that is the fix.
- [ ] Backfill descriptions, then drop `paragliderstats.com` from `LEGACY_DESCRIPTION_DOMAINS`.

> [!WARNING]
> **Do not run a deploy from `main` before this merges.** `deploy.yml` triggers on push to `main`
> and applies `infra/` from that branch, where `local.domain` is still `paragliderstats.com`. That
> would destroy the `ploufbag-com` zone and recreate mappings against a domain with no
> nameservers. The destructive-change guard would not stop it — it protects the database, the
> function bucket and the `random_*` resources, not DNS zones.
