### PR TITLE
fix: Recognise parastats.info and stop matching pilots' own emoji

### DIFF
--- a/common/src/descriptionFooter.test.ts
+++ b/common/src/descriptionFooter.test.ts
@@ -85,3 +85,68 @@ describe("formattedStatsPattern", () => {
         expect(formattedStatsPattern()).not.toBe(formattedStatsPattern());
     });
 });
+
+// ---------------------------------------------------------------------------
+// Regression cases taken verbatim from production rows, found while preparing
+// the ploufbag.com backfill on 2026-08-15.
+// ---------------------------------------------------------------------------
+
+describe("real production descriptions", () => {
+    // 4 live flights look exactly like this. Before parastats.info was added to
+    // the legacy list these read as unformatted, took the append branch, and
+    // came out with two stacked stats blocks.
+    const PARASTATS_INFO_ONLY = [
+        "🪂 Ronin  14 flights / 1h 43min",
+        "2025        1 flight / 6min",
+        "All Time    106 flights / 24h 40min",
+        "🌐 parastats.info",
+    ].join("\n");
+
+    // 1 live flight, already corrupted by the previous migration: two stats
+    // blocks, two footers, two different legacy domains.
+    const ALREADY_CORRUPTED = [
+        "🦋 Almost caught the metamorphosis of a wingsuiter",
+        "↗️ Plan de l'Aiguille",
+        "↘️ Le Bois du Bouchet",
+        "🪂 Ronin  28 flights / 3h 43min",
+        "All Time    141 flights / 35h 44min",
+        "🌐 paragliderstats.com  28 flights / 3h 43min",
+        "All Time    141 flights / 35h 44min",
+        "🌐 parastats.info",
+    ].join("\n");
+
+    it("recognises a parastats.info footer as formatted", () => {
+        expect(isFormattedDescription(PARASTATS_INFO_ONLY)).toBe(true);
+    });
+
+    it("rewrites a parastats.info description to a single clean block", () => {
+        const updated = PARASTATS_INFO_ONLY.replace(formattedStatsPattern(), NEW_STATS);
+
+        expect(updated).toBe(NEW_STATS);
+        expect(updated.split("🌐").length - 1).toBe(1);
+    });
+
+    it("collapses an already-corrupted description down to one stats block", () => {
+        const updated = ALREADY_CORRUPTED.replace(formattedStatsPattern(), NEW_STATS);
+
+        expect(updated.split("🌐").length - 1).toBe(1);
+        expect(updated).not.toContain("parastats.info");
+        expect(updated).not.toContain("paragliderstats.com");
+    });
+
+    // The data-loss regression. 🦋 (U+1F98B) shares its lead surrogate \uD83E
+    // with 🪂 (U+1FA82), so without the `u` flag the match started at the
+    // pilot's own words and replacing it deleted them.
+    it("preserves pilot prose that opens with an unrelated emoji", () => {
+        const updated = ALREADY_CORRUPTED.replace(formattedStatsPattern(), NEW_STATS);
+
+        expect(updated).toContain("🦋 Almost caught the metamorphosis of a wingsuiter");
+        expect(updated).toBe(`🦋 Almost caught the metamorphosis of a wingsuiter\n${NEW_STATS}`);
+    });
+
+    it("still anchors on a takeoff arrow when there is no prose", () => {
+        const arrowFirst = ["↗️ Chamonix", "↘️ Bouchet", "🪂 Ronin  1 flight", "🌐 ploufbag.com"].join("\n");
+
+        expect(arrowFirst.replace(formattedStatsPattern(), NEW_STATS)).toBe(NEW_STATS);
+    });
+});

--- a/common/src/descriptionFooter.ts
+++ b/common/src/descriptionFooter.ts
@@ -22,7 +22,13 @@ export const DESCRIPTION_DOMAIN = 'ploufbag.com';
  * a stats block rather than replacing one. The visible symptom is an activity
  * with two stats blocks, and it is not self-healing.
  */
-export const LEGACY_DESCRIPTION_DOMAINS = ['paragliderstats.com'] as const;
+export const LEGACY_DESCRIPTION_DOMAINS = [
+    'paragliderstats.com',
+    // Predates paragliderstats.com. Missing from this list until 2026-08-15, which
+    // is why 5 live flights carry it — 4 cleanly, and 1 with two stacked stats
+    // blocks, the exact corruption described above from the previous migration.
+    'parastats.info',
+] as const;
 
 export const DESCRIPTION_FOOTER = `🌐 ${DESCRIPTION_DOMAIN}`;
 
@@ -37,15 +43,24 @@ const DOMAIN_ALTERNATION = ALL_DESCRIPTION_DOMAINS
  * Matches an existing stats block: from the first stats glyph through to the
  * footer domain.
  *
- * The character class is carried over verbatim from the original expression.
- * These glyphs are not single UTF-16 code units — 🪂 is a surrogate pair and
- * ↗️/↘️ are a base arrow plus U+FE0F — so without the `u` flag the class matches
- * their constituent units rather than the glyphs as such. That is loose, but it
- * is the behaviour that has been matching real descriptions in production, and a
- * domain migration is the wrong moment to also tighten it.
+ * The `u` flag is load-bearing and must not be dropped. Without it the character
+ * class is a set of UTF-16 *code units*, not characters: 🪂 is U+1FA82, i.e. the
+ * surrogate pair 🪂, so an unflagged class contains the bare lead
+ * surrogate \uD83E. That lead is shared by every emoji in U+1F900–U+1FAFF — 🦋,
+ * 🥇, 🧗 and hundreds more — so the class matched the first half of whichever
+ * emoji a pilot had opened their own text with. Combined with the greedy
+ * `[\s\S]*`, the match then began at the pilot's prose instead of at our stats
+ * block, and replacing it silently deleted what they had written.
+ *
+ * That stayed invisible while such descriptions took the *append* branch. Adding
+ * their footer domain to the legacy list routes them to this replace branch,
+ * which is what turned latent looseness into data loss.
+ *
+ * With `u`, the class is three characters (plus the U+FE0F variation selectors
+ * that follow ↗/↘), and matching starts at a real stats glyph.
  */
 export function formattedStatsPattern(): RegExp {
-    return new RegExp(`[🪂↗️↘️][\\s\\S]*(?:${DOMAIN_ALTERNATION})`);
+    return new RegExp(`[🪂↗️↘️][\\s\\S]*(?:${DOMAIN_ALTERNATION})`, 'u');
 }
 
 /**


### PR DESCRIPTION
## Why

Found while preparing the ploufbag.com description backfill (#22 follow-up), by reading the live
`flights` rows before writing anything to Strava. **The backfill was not run** — it would have
corrupted data. Two separate defects, and they are not independently shippable.

## Defect 1 — `parastats.info` was missing from the legacy domain list

It predates `paragliderstats.com`. Five live flights still carry it:

| | Count |
|---|---|
| `parastats.info` | 5 |
| `paragliderstats.com` | 60 |
| both (already corrupted) | 1 |
| more than one `🌐` footer | 1 |

Four are cleanly formatted. Without the domain in the list they read as *unformatted*, take the
append branch (`replace('🪂 ' + wing, stats)`, which swaps only the first line), and end up with
two stacked stats blocks.

The fifth already looks exactly like that — the *previous* migration made this same mistake. That
row is how the domain was discovered at all:

```
🦋 Almost caught the metamorphosis of a wingsuiter
↗️ Plan de l'Aiguille
🪂 Ronin  28 flights / 3h 43min
All Time    141 flights / 35h 44min
🌐 paragliderstats.com  28 flights / 3h 43min     ← second block starts mid-footer
All Time    141 flights / 35h 44min
🌐 parastats.info
```

## Defect 2 — the pattern matched pilots' own emoji, deleting their text

`formattedStatsPattern()` had no `u` flag, so `[🪂↗️↘️]` was a set of UTF-16 **code units**, not
characters. `🪂` is U+1FA82 → `🪂`, and that lead surrogate `\uD83E` is shared by every
emoji in **U+1F900–U+1FAFF** — 🦋, 🥇, 🧗 and hundreds more.

So the class matched the first half of whichever emoji a pilot opened their description with, the
greedy `[\s\S]*` ran from there to the last domain, and replacing the match **silently deleted
their own words**. The row above would have lost its `🦋 Almost caught…` line entirely.

Verified against the real string before and after:

```
loose   prose_preserved=LOST  footers=1
u-flag  prose_preserved=ok    footers=1
```

### The two fixes are coupled

Defect 2 was latent precisely *because* those descriptions took the append branch. Adding their
footer to the legacy list is what routes them to the replace branch — turning harmless looseness
into data loss. Shipping the legacy domain **without** the `u` flag would actively destroy prose.

This also corrects a judgement call in #22, where I preserved the unflagged class on the grounds
that it was "the behaviour that has been matching real descriptions in production". That was true
but incomplete: it was safe only on the append path.

## Test plan

- [x] `cd common && yarn test` — 16 passed (5 new, built verbatim from the production rows)
- [x] **Mutation-checked**: reverting either fix fails 4 tests; both applied, 16 pass
- [x] `cd common && yarn build` — clean
- [ ] `cd functions && yarn test` / `cd site && yarn build` — delegated to CI (no container runtime locally)

## After merge

Deploy, then run the backfill over **64** flights (60 + the 4 `parastats.info`-only ones, which
the current list misses). Only once that is confirmed clean should either legacy domain come out
of `LEGACY_DESCRIPTION_DOMAINS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ya9DbiQmKouVXAinWtkRj
