### PR TITLE
refactor: Rebrand user-facing strings to Plouf Bag

### DIFF
--- a/site/src/app/login/page.tsx
+++ b/site/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 import styles from "@styles/Page.module.css";
 import {Metadata} from "next";
 import {createMetadata} from "@ui/metadata";
+import {BRAND_NAME} from "@ui/brand";
 
 export const metadata: Metadata = createMetadata('Login')
 
@@ -10,7 +11,7 @@ export default function Login() {
             <div style={{ marginBottom: 'var(--space-6)' }}>
                 <div style={{ fontSize: '3rem', marginBottom: 'var(--space-4)' }}>🪂</div>
                 <h1 className={styles.title} style={{ fontSize: 'var(--font-size-3xl)', marginBottom: 'var(--space-3)' }}>
-                    Welcome to Paraglider Stats
+                    Welcome to {BRAND_NAME}
                 </h1>
                 <p className={styles.subtitle} style={{ fontSize: 'var(--font-size-lg)', marginBottom: '0' }}>
                     Track your paragliding adventures with data from Strava
@@ -26,7 +27,7 @@ export default function Login() {
 
             <div className={styles.loginFeatures} style={{ marginBottom: 'var(--space-6)' }}>
                 <h3 style={{ marginBottom: 'var(--space-3)', fontSize: 'var(--font-size-base)', fontWeight: 'var(--font-weight-semibold)' }}>
-                    How Parastats enhances your Strava activities:
+                    How {BRAND_NAME} enhances your Strava activities:
                 </h3>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
                     <div style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-3)' }}>

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,12 +1,13 @@
 import Head from "next/head";
 import styles from "@styles/Page.module.css";
+import {BRAND_NAME} from "@ui/brand";
 
 export default function Home() {
     return (
         <div className={styles.pageCentered}>
 
             <h1 className={styles.title}>
-                Welcome to Paraglider Stats.
+                Welcome to {BRAND_NAME}.
             </h1>
 
             <h2 className={styles.subtitle}>Coming soon...</h2>

--- a/site/src/app/styleguide/page.tsx
+++ b/site/src/app/styleguide/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import styles from './StyleGuide.module.css';
+import {BRAND_NAME} from '@ui/brand';
 
 export default function StyleGuidePage() {
   return (
     <div className={styles.styleguide}>
       <header className={styles.header}>
-        <h1>Parastats Design System</h1>
+        <h1>{BRAND_NAME} Design System</h1>
         <p>Living style guide for ploufbag.com</p>
       </header>
 

--- a/site/src/app/welcome/page.tsx
+++ b/site/src/app/welcome/page.tsx
@@ -3,6 +3,7 @@ import {get} from "@database/pilots";
 import styles from "@styles/Page.module.css";
 import {Metadata} from "next";
 import {createMetadata} from "@ui/metadata";
+import {BRAND_NAME} from "@ui/brand";
 
 export const metadata: Metadata = createMetadata('Welcome')
 
@@ -19,7 +20,7 @@ export default async function Welcome() {
     return (
         <div className={styles.page}>
             <h1 className={styles.title}>
-                Welcome to Paraglider Stats, {pilot.first_name}
+                Welcome to {BRAND_NAME}, {pilot.first_name}
             </h1>
         </div>
     );

--- a/site/src/ui/Header.tsx
+++ b/site/src/ui/Header.tsx
@@ -2,6 +2,7 @@ import {Auth} from "@auth/index";
 import styles from "@styles/Header.module.css";
 import {SignOut} from "@ui/SignOut";
 import {headers} from "next/headers";
+import {BRAND_NAME} from "@ui/brand";
 
 
 enum AuthRequired {
@@ -50,7 +51,7 @@ export default async function Header() {
         <div className={styles.content}>
             <a href="/" className={styles.headerTitle}>
                 <span>🪂</span>
-                <span>Paraglider Stats</span>
+                <span>{BRAND_NAME}</span>
             </a>
             {!isHomePage && (
                 <nav className={styles.nav}>

--- a/site/src/ui/brand.ts
+++ b/site/src/ui/brand.ts
@@ -1,0 +1,12 @@
+/**
+ * The product's user-facing name, in one place.
+ *
+ * It was previously seven literals across five files, and had already drifted:
+ * five said "Paraglider Stats" and two said "Parastats". Scattered brand
+ * literals are the same shape of problem as the scattered Strava footer
+ * domains, which drifted into two separate data-corruption bugs.
+ *
+ * Deliberately not derived from the domain. `ploufbag.com` is one word because
+ * domains have to be; the name is two.
+ */
+export const BRAND_NAME = "Plouf Bag";

--- a/site/src/ui/metadata.ts
+++ b/site/src/ui/metadata.ts
@@ -1,8 +1,9 @@
 import {Metadata} from "next";
+import {BRAND_NAME} from "@ui/brand";
 
 export function createMetadata(subtitle: string = null): Metadata {
     return {
-        title: subtitle ? `Paraglider Stats • ${subtitle}` : `Paraglider Stats`,
+        title: subtitle ? `${BRAND_NAME} • ${subtitle}` : BRAND_NAME,
         icons: './favicon.ico',
     }
 }


### PR DESCRIPTION
## Scope

**Step 1 of 3.** User-facing copy only. `@parastats/*` package scope and the repository name
follow in separate PRs, as agreed.

The name is **Plouf Bag** — two words. Deliberately *not* derived from the domain: `ploufbag.com`
is one word because domains have to be.

## What changed

| File | Before | After |
|---|---|---|
| `ui/Header.tsx` | `Paraglider Stats` | `{BRAND_NAME}` |
| `ui/metadata.ts` | `Paraglider Stats • {sub}` | `${BRAND_NAME} • ${sub}` |
| `app/page.tsx` | `Welcome to Paraglider Stats.` | `Welcome to {BRAND_NAME}.` |
| `app/welcome/page.tsx` | `Welcome to Paraglider Stats, {name}` | `Welcome to {BRAND_NAME}, {name}` |
| `app/login/page.tsx` | `Welcome to Paraglider Stats` | `Welcome to {BRAND_NAME}` |
| `app/login/page.tsx` | `How **Parastats** enhances…` | `How {BRAND_NAME} enhances…` |
| `app/styleguide/page.tsx` | `**Parastats** Design System` | `{BRAND_NAME} Design System` |

## Why a constant rather than seven literals

The name had **already drifted** before this change — five places said "Paraglider Stats", two
said "Parastats". That is the same shape of problem as the scattered Strava footer domain, which
drifted into two separate data-corruption bugs earlier today (#23). One exported constant makes
the next rename a one-line diff and makes drift impossible.

## Not in this PR

- `ParastatsApi` (`site/src/data/api/index.ts`) — internal class name, step 2
- `@parastats/common` package scope — step 2
- Repository name — step 3
- `🌐 ploufbag.com` in Strava descriptions — already live on all 274 flights

## Test plan

- [x] `npx tsc --noEmit` in `site` — no new errors. The only errors are pre-existing, all in
      `app/api/admin/monitoring/stats/route.unit.test.ts` (vitest mock typing), untouched here.
      Typecheck also caught a real miss mid-change: `{BRAND_NAME}` used in `welcome/page.tsx`
      without its import. Fixed before commit.
- [x] `grep` sweep confirms no user-facing `Paraglider Stats` / `Parastats` remains
- [ ] `site (build)` and the rest — delegated to CI (no container runtime on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ya9DbiQmKouVXAinWtkRj
