### PR TITLE
refactor: Rename package scope from @parastats to @ploufbag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           cache: yarn
           cache-dependency-path: functions/yarn.lock
 
-      # functions depends on @parastats/common via file:../common, and its build
+      # functions depends on @ploufbag/common via file:../common, and its build
       # copies ../common/dist wholesale. Without this the tests run against a
       # stale or absent common build.
       - run: yarn install --frozen-lockfile && yarn build

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@parastats/common",
+  "name": "@ploufbag/common",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@parastats/common",
+      "name": "@ploufbag/common",
       "version": "0.1.0",
       "dependencies": {
         "@googlemaps/polyline-codec": "^1.0.28",

--- a/common/package.json
+++ b/common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@parastats/common",
+  "name": "@ploufbag/common",
   "author": "theostanton",
   "version": "0.1.0",
   "license": "MIT",

--- a/fix-either.sh
+++ b/fix-either.sh
@@ -6,14 +6,14 @@ cd /Users/theopersonal/Library/Mobile\ Documents/com~apple~CloudDocs/Code/parast
 
 # Add isSuccess import where needed
 find . -name "*.ts" -exec grep -l "\.success" {} \; | xargs grep -L "isSuccess" | while read file; do
-    # Check if file already imports from @parastats/common
-    if grep -q "from \"@parastats/common\"" "$file"; then
+    # Check if file already imports from @ploufbag/common
+    if grep -q "from \"@ploufbag/common\"" "$file"; then
         # Add isSuccess to existing import
-        sed -i '' 's/} from "@parastats\/common";/, isSuccess} from "@parastats\/common";/g' "$file"
+        sed -i '' 's/} from "@ploufbag\/common";/, isSuccess} from "@ploufbag\/common";/g' "$file"
     else
         # Add new import line
         sed -i '' '1i\
-import {isSuccess} from "@parastats/common";
+import {isSuccess} from "@ploufbag/common";
 ' "$file"
     fi
 done

--- a/functions/dev.Dockerfile
+++ b/functions/dev.Dockerfile
@@ -21,12 +21,12 @@ WORKDIR /app
 COPY functions/package.json ./
 COPY functions/yarn.lock ./
 # Remove common package dependency for development and install
-RUN sed -i '/"@parastats\/common":/d' package.json
+RUN sed -i '/"@ploufbag\/common":/d' package.json
 RUN yarn install
 
 # Create node_modules symlink to built common package
-RUN mkdir -p node_modules/@parastats
-RUN ln -sf /app/common node_modules/@parastats/common
+RUN mkdir -p node_modules/@ploufbag
+RUN ln -sf /app/common node_modules/@ploufbag/common
 
 # Copy source files
 COPY functions/src ./src

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@google-cloud/tasks": "^6.0.1",
         "@googlemaps/polyline-codec": "^1.0.28",
-        "@parastats/common": "file:../common",
+        "@ploufbag/common": "file:../common",
         "@turf/distance": "^7.2.0",
         "@turf/helpers": "^7.2.0",
         "@types/generic-pool": "^3.8.3",
@@ -35,7 +35,7 @@
       }
     },
     "../common": {
-      "name": "@parastats/common",
+      "name": "@ploufbag/common",
       "version": "0.1.0",
       "dependencies": {
         "generic-pool": "^3.9.0",
@@ -323,7 +323,7 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@parastats/common": {
+    "node_modules/@ploufbag/common": {
       "resolved": "../common",
       "link": true
     },

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@google-cloud/tasks": "^6.2.1",
     "@googlemaps/polyline-codec": "^1.0.28",
-    "@parastats/common": "file:../common",
+    "@ploufbag/common": "file:../common",
     "@turf/distance": "^7.3.1",
     "@turf/helpers": "^7.3.1",
     "@types/generic-pool": "^3.8.3",

--- a/functions/package.prod.json
+++ b/functions/package.prod.json
@@ -13,6 +13,6 @@
     "ts-postgres": "^2.0.4",
     "@turf/distance": "^7.2.0",
     "@turf/helpers": "^7.2.0",
-    "@parastats/common": "file:./common"
+    "@ploufbag/common": "file:./common"
   }
 }

--- a/functions/src/api/admin/monitoring.ts
+++ b/functions/src/api/admin/monitoring.ts
@@ -5,7 +5,7 @@ import {
     WebhookEvents,
     TaskExecutions,
     withPooledClient
-} from "@parastats/common";
+} from "@ploufbag/common";
 import { retryFailedTasks } from "../../tasks/monitoredTaskExecutor";
 
 /**

--- a/functions/src/api/generateToken.ts
+++ b/functions/src/api/generateToken.ts
@@ -1,6 +1,6 @@
 import {Request, Response} from "express";
 import {extractPilotFromJwt, generateJwt, sign} from "@/jwt";
-import {Pilots, isSuccess} from "@parastats/common";
+import {Pilots, isSuccess} from "@ploufbag/common";
 import {StravaAthleteId} from "@/stravaApi/model";
 
 export async function generateToken(req: Request, res: Response) {

--- a/functions/src/api/getFlights.ts
+++ b/functions/src/api/getFlights.ts
@@ -1,6 +1,6 @@
 import {Request, Response} from "express";
 import {extractPilotFromJwt} from "@/jwt";
-import {Flights, isSuccess} from "@parastats/common";
+import {Flights, isSuccess} from "@ploufbag/common";
 
 export async function getFlights(req: Request, res: Response) {
 

--- a/functions/src/api/index.ts
+++ b/functions/src/api/index.ts
@@ -1,4 +1,4 @@
-import {isSuccess} from "@parastats/common";
+import {isSuccess} from "@ploufbag/common";
 import express, {Request, Response} from "express";
 import {verifyJwt} from "@/jwt";
 import bodyParser from "body-parser";

--- a/functions/src/jwt.ts
+++ b/functions/src/jwt.ts
@@ -1,6 +1,6 @@
 import jwt from "jsonwebtoken";
 import {Request, Response} from "express";
-import {Pilots, PilotRow, failed, Either, success, isSuccess} from "@parastats/common";
+import {Pilots, PilotRow, failed, Either, success, isSuccess} from "@ploufbag/common";
 
 export function generateJwt(userId: number): string {
     console.log(`generateJwt process.env.SESSION_SECRET=${process.env.SESSION_SECRET}`)

--- a/functions/src/model/database/DescriptionPreferences.ts
+++ b/functions/src/model/database/DescriptionPreferences.ts
@@ -1,7 +1,7 @@
-import {Either, failed, failure, success} from "@parastats/common";
+import {Either, failed, failure, success} from "@ploufbag/common";
 import {withPooledClient} from "./client";
-import {DescriptionPreference, PilotRow} from "@parastats/common";
-import {StravaAthleteId} from "@parastats/common";
+import {DescriptionPreference, PilotRow} from "@ploufbag/common";
+import {StravaAthleteId} from "@ploufbag/common";
 
 export namespace DescriptionPreferences {
 

--- a/functions/src/model/database/Flights.ts
+++ b/functions/src/model/database/Flights.ts
@@ -1,7 +1,7 @@
 import {withPooledClient, Client} from "./client";
-import {Either, failed, failure, success} from "@parastats/common";
-import {FlightRow} from "@parastats/common";
-import {StravaActivityId, StravaAthleteId} from "@parastats/common";
+import {Either, failed, failure, success} from "@ploufbag/common";
+import {FlightRow} from "@ploufbag/common";
+import {StravaActivityId, StravaAthleteId} from "@ploufbag/common";
 
 export namespace Flights {
     export async function get(flightId: StravaActivityId): Promise<Either<FlightRow>> {

--- a/functions/src/model/database/Mocks.test.ts
+++ b/functions/src/model/database/Mocks.test.ts
@@ -1,4 +1,4 @@
-import {FlightRow, LatLng, PilotRowFull, Site} from "@parastats/common";
+import {FlightRow, LatLng, PilotRowFull, Site} from "@ploufbag/common";
 
 function randomBigInt(): number {
     return Math.floor(Math.random() * 100000);

--- a/functions/src/model/database/Pilots.test.ts
+++ b/functions/src/model/database/Pilots.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from "vitest";
 import {end} from "./client";
 import {Pilots} from "./Pilots";
-import {PilotRowFull} from "@parastats/common";
+import {PilotRowFull} from "@ploufbag/common";
 import {TestContainer} from "./generateContainer.test";
 
 test('Test insert() / get() / getToken()', async () => {

--- a/functions/src/model/database/Pilots.ts
+++ b/functions/src/model/database/Pilots.ts
@@ -6,7 +6,7 @@ import {
     PilotRowFull,
     StravaAthleteId,
     Either, failure
-} from "@parastats/common";
+} from "@ploufbag/common";
 import axios from "axios";
 
 export namespace Pilots {

--- a/functions/src/model/database/Sites.test.ts
+++ b/functions/src/model/database/Sites.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from "vitest";
 import {TestContainer} from "./generateContainer.test";
-import {Site} from "@parastats/common";
+import {Site} from "@ploufbag/common";
 import {Sites} from "./Sites";
 import {Mocks} from "./Mocks.test";
 import {end, withPooledClient} from "./client";

--- a/functions/src/model/database/Sites.ts
+++ b/functions/src/model/database/Sites.ts
@@ -1,5 +1,5 @@
-import {Either, LatLng, Site} from "@parastats/common";
-import {failed, success} from "@parastats/common";
+import {Either, LatLng, Site} from "@ploufbag/common";
+import {failed, success} from "@ploufbag/common";
 import {withPooledClient, Client} from "./client";
 
 export namespace Sites {

--- a/functions/src/model/database/Windsocks.ts
+++ b/functions/src/model/database/Windsocks.ts
@@ -1,5 +1,5 @@
-import {Either, Windsock} from "@parastats/common";
-import {failed, success} from "@parastats/common";
+import {Either, Windsock} from "@ploufbag/common";
+import {failed, success} from "@ploufbag/common";
 import {withPooledClient, Client} from "./client";
 
 export namespace Windsocks {

--- a/functions/src/model/database/client.ts
+++ b/functions/src/model/database/client.ts
@@ -6,4 +6,4 @@ export {
   setTestClient as setClient, 
   closeAllConnections as end,
   type Client 
-} from '@parastats/common';
+} from '@ploufbag/common';

--- a/functions/src/model/database/generateContainer.test.ts
+++ b/functions/src/model/database/generateContainer.test.ts
@@ -1,7 +1,7 @@
 import {PostgreSqlContainer, StartedPostgreSqlContainer} from "@testcontainers/postgresql";
 import {connect} from "ts-postgres";
 import {end, setClient} from "./client";
-import {DescriptionPreference, FlightRow, PilotRowFull, Site, isSuccess} from "@parastats/common";
+import {DescriptionPreference, FlightRow, PilotRowFull, Site, isSuccess} from "@ploufbag/common";
 import {Pilots} from "./Pilots";
 import {Flights} from "./Flights";
 import * as fs from "node:fs";

--- a/functions/src/model/database/model.ts
+++ b/functions/src/model/database/model.ts
@@ -1,5 +1,5 @@
 import {StravaActivityId, StravaAthleteId} from "@/stravaApi/model";
-import {LatLng, Polyline, SiteType} from '@parastats/common';
+import {LatLng, Polyline, SiteType} from '@ploufbag/common';
 
 export {LatLng, Polyline, SiteType};
 

--- a/functions/src/model/ffvlApi/index.ts
+++ b/functions/src/model/ffvlApi/index.ts
@@ -1,4 +1,4 @@
-import {Either, failure, success, WindDirection} from "@parastats/common";
+import {Either, failure, success, WindDirection} from "@ploufbag/common";
 import axios from "axios";
 import {FfvlReport, WindsockReport} from "@/ffvlApi/model";
 

--- a/functions/src/model/ffvlApi/model.ts
+++ b/functions/src/model/ffvlApi/model.ts
@@ -1,4 +1,4 @@
-import {WindDirection} from "@parastats/common";
+import {WindDirection} from "@ploufbag/common";
 
 export type FfvlBalise = {
     nom: string

--- a/functions/src/model/stravaApi/index.test.ts
+++ b/functions/src/model/stravaApi/index.test.ts
@@ -1,4 +1,4 @@
-import {isSuccess} from "@parastats/common";
+import {isSuccess} from "@ploufbag/common";
 import {beforeAll, expect, it, test} from "vitest";
 import {StravaApi} from "./index";
 import {Pilots} from "../database/Pilots";

--- a/functions/src/model/stravaApi/index.ts
+++ b/functions/src/model/stravaApi/index.ts
@@ -1,5 +1,5 @@
 import axios, {AxiosHeaders} from "axios";
-import {StravaActivityId, failed, Either, success, Pilots, isSuccess} from "@parastats/common";
+import {StravaActivityId, failed, Either, success, Pilots, isSuccess} from "@ploufbag/common";
 import {StravaActivity, StravaActivitySummary, StravaAthlete, isRelevantActivityType} from "@/stravaApi/model";
 
 export class StravaApi {

--- a/functions/src/model/stravaApi/model.ts
+++ b/functions/src/model/stravaApi/model.ts
@@ -1,4 +1,4 @@
-import { StravaActivityId, StravaAthleteId } from '@parastats/common';
+import { StravaActivityId, StravaAthleteId } from '@ploufbag/common';
 
 export { StravaActivityId, StravaAthleteId };
 

--- a/functions/src/tasks/fetchAllActivities.ts
+++ b/functions/src/tasks/fetchAllActivities.ts
@@ -1,6 +1,6 @@
-import {isSuccess} from "@parastats/common";
-import { FetchAllActivitiesTask, TaskResult, StravaActivityId, StravaAthleteId, FlightRow } from '@parastats/common';
-import { withPooledClient } from '@parastats/common';
+import {isSuccess} from "@ploufbag/common";
+import { FetchAllActivitiesTask, TaskResult, StravaActivityId, StravaAthleteId, FlightRow } from '@ploufbag/common';
+import { withPooledClient } from '@ploufbag/common';
 import { Pilots } from '@/database/Pilots';
 import { Flights } from '@/database/Flights';
 import { StravaApi } from '@/stravaApi';

--- a/functions/src/tasks/fetchAllActivities/StravaActivityToFlightConverter.ts
+++ b/functions/src/tasks/fetchAllActivities/StravaActivityToFlightConverter.ts
@@ -1,5 +1,5 @@
 import {StravaActivity, StravaAthleteId} from "@/stravaApi/model";
-import {FlightRow, LatLng, Polyline, isSuccess, Either, Sites, failure, isFailure, success} from "@parastats/common";
+import {FlightRow, LatLng, Polyline, isSuccess, Either, Sites, failure, isFailure, success} from "@ploufbag/common";
 import {decode, LatLngTuple} from "@googlemaps/polyline-codec";
 
 type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>

--- a/functions/src/tasks/fetchAllActivities/index.ts
+++ b/functions/src/tasks/fetchAllActivities/index.ts
@@ -1,6 +1,6 @@
 import {TaskBody, TaskResult} from "@/tasks/model";
 import {StravaApi} from "@/stravaApi";
-import {withPooledClient, Pilots, Flights, FlightRow, isSuccess} from "@parastats/common";
+import {withPooledClient, Pilots, Flights, FlightRow, isSuccess} from "@ploufbag/common";
 import {StravaActivity, StravaActivityId} from "@/stravaApi/model";
 import axios, {AxiosHeaders} from "axios";
 import {StravaActivityToFlightConverter} from "./StravaActivityToFlightConverter";

--- a/functions/src/tasks/fetchAllActivities/test.ts
+++ b/functions/src/tasks/fetchAllActivities/test.ts
@@ -1,7 +1,7 @@
-import {isSuccess} from "@parastats/common";
+import {isSuccess} from "@ploufbag/common";
 import {expect, test} from "vitest";
 import initialiseUser from "./index";
-import {FetchAllActivitiesTask, UpdateDescriptionTask} from "@parastats/common";
+import {FetchAllActivitiesTask, UpdateDescriptionTask} from "@ploufbag/common";
 
 test("fetchAllActivities success", async () => {
     const input: FetchAllActivitiesTask = {

--- a/functions/src/tasks/helloWorld.ts
+++ b/functions/src/tasks/helloWorld.ts
@@ -1,4 +1,4 @@
-import { HelloWorldTask, TaskResult } from '@parastats/common';
+import { HelloWorldTask, TaskResult } from '@ploufbag/common';
 
 export async function executeHelloWorldTask(
     task: HelloWorldTask

--- a/functions/src/tasks/index.ts
+++ b/functions/src/tasks/index.ts
@@ -1,5 +1,5 @@
 import {Request, Response} from "express";
-import {TaskBody, isSuccess} from "@parastats/common";
+import {TaskBody, isSuccess} from "@ploufbag/common";
 import {taskHandlers} from "@/tasks/model";
 
 export default async function handler(req: Request, res: Response): Promise<void> {

--- a/functions/src/tasks/model.ts
+++ b/functions/src/tasks/model.ts
@@ -3,7 +3,7 @@ import { executeUpdateDescriptionTask } from "./updateDescription";
 import { executeUpdateSingleActivityTask } from "./updateSingleActivity";
 import { executeHelloWorldTask } from "./helloWorld";
 import { executeSyncSitesTask } from "./syncSites";
-import { FetchAllActivitiesTask, UpdateDescriptionTask, UpdateSingleActivityTask, HelloWorldTask, SyncSitesTask } from "@parastats/common";
+import { FetchAllActivitiesTask, UpdateDescriptionTask, UpdateSingleActivityTask, HelloWorldTask, SyncSitesTask } from "@ploufbag/common";
 
 export type TaskResult = TaskSuccess | TaskFailure
 

--- a/functions/src/tasks/monitoredTaskExecutor.ts
+++ b/functions/src/tasks/monitoredTaskExecutor.ts
@@ -4,7 +4,7 @@ import {
     TaskExecutionStatus,
     TaskExecutions,
     withPooledClient
-, isSuccess} from "@parastats/common";
+, isSuccess} from "@ploufbag/common";
 import { taskHandlers } from "./model";
 
 /**

--- a/functions/src/tasks/syncSites.ts
+++ b/functions/src/tasks/syncSites.ts
@@ -1,4 +1,4 @@
-import {Either, failed, isSuccess, success, SyncSitesTask} from "@parastats/common";
+import {Either, failed, isSuccess, success, SyncSitesTask} from "@ploufbag/common";
 import {Site, SiteType, Windsock, LatLng} from '@/database/model';
 import {Flights} from '@/database/Flights';
 import {Sites} from '@/database/Sites';

--- a/functions/src/tasks/syncSites/index.ts
+++ b/functions/src/tasks/syncSites/index.ts
@@ -1,12 +1,12 @@
 import {TaskBody, TaskResult} from "@/tasks/model";
 import axios from "axios";
-import {LatLng, Site, SiteType, Windsock, isSuccess, isFailure} from "@parastats/common";
-import {Sites} from "@parastats/common";
-import {Windsocks} from "@parastats/common";
+import {LatLng, Site, SiteType, Windsock, isSuccess, isFailure} from "@ploufbag/common";
+import {Sites} from "@ploufbag/common";
+import {Windsocks} from "@ploufbag/common";
 
 import getDistance from "@turf/distance"
 import {Coord, Units} from "@turf/helpers"
-import {Flights} from "@parastats/common";
+import {Flights} from "@ploufbag/common";
 import {FfvlBalise, FfvlSite} from "@/ffvlApi/model";
 
 export type SyncSitesTask = {

--- a/functions/src/tasks/trigger.ts
+++ b/functions/src/tasks/trigger.ts
@@ -1,4 +1,4 @@
-import {TaskBody, TaskName, failed, Either, success} from "@parastats/common";
+import {TaskBody, TaskName, failed, Either, success} from "@ploufbag/common";
 
 const {CloudTasksClient} = require('@google-cloud/tasks').v2;
 

--- a/functions/src/tasks/updateDescription.ts
+++ b/functions/src/tasks/updateDescription.ts
@@ -6,7 +6,7 @@ import {
     FlightRow,
     isFormattedDescription,
     formattedStatsPattern
-} from "@parastats/common";
+} from "@ploufbag/common";
 import {Pilots} from '@/database/Pilots';
 import {Flights} from '@/database/Flights';
 import {StravaApi} from '@/stravaApi';

--- a/functions/src/tasks/updateDescription/DescriptionFormatter.ts
+++ b/functions/src/tasks/updateDescription/DescriptionFormatter.ts
@@ -1,8 +1,8 @@
-import {DESCRIPTION_FOOTER, DescriptionPreference, FlightRow, isSuccess, SiteType, WindDirection} from "@parastats/common";
-import {withPooledClient, Client} from "@parastats/common";
+import {DESCRIPTION_FOOTER, DescriptionPreference, FlightRow, isSuccess, SiteType, WindDirection} from "@ploufbag/common";
+import {withPooledClient, Client} from "@ploufbag/common";
 import {FFVL} from "@/ffvlApi";
-import {DescriptionPreferences} from "@parastats/common";
-import {StravaAthleteId} from "@parastats/common";
+import {DescriptionPreferences} from "@ploufbag/common";
+import {StravaAthleteId} from "@ploufbag/common";
 import {formatSiteName} from "@/utils/formatSiteName";
 
 export type AggregationResult = {

--- a/functions/src/tasks/updateDescription/DescriptionFormatterAdapter.ts
+++ b/functions/src/tasks/updateDescription/DescriptionFormatterAdapter.ts
@@ -7,7 +7,7 @@ import {
     DescriptionPreferences,
     isSuccess,
     WindReport
-} from "@parastats/common";
+} from "@ploufbag/common";
 import {FFVL} from "@/ffvlApi";
 
 // Adapter to bridge DescriptionPreferences to common PreferencesProvider interface

--- a/functions/src/tasks/updateDescription/index.ts
+++ b/functions/src/tasks/updateDescription/index.ts
@@ -1,5 +1,5 @@
 import {TaskResult, TaskBody} from "@/tasks/model";
-import {Pilots, Flights, isSuccess, isFormattedDescription, formattedStatsPattern} from "@parastats/common";
+import {Pilots, Flights, isSuccess, isFormattedDescription, formattedStatsPattern} from "@ploufbag/common";
 import {StravaApi} from "@/stravaApi";
 import {StravaActivityId} from "@/stravaApi/model";
 import {generateStats} from "./updateActivityDescription";

--- a/functions/src/tasks/updateDescription/test.ts
+++ b/functions/src/tasks/updateDescription/test.ts
@@ -1,7 +1,7 @@
-import {isSuccess} from "@parastats/common";
+import {isSuccess} from "@ploufbag/common";
 import {expect, test} from "vitest";
 import handler from "./index";
-import {FetchAllActivitiesTask, UpdateDescriptionTask} from "@parastats/common";
+import {FetchAllActivitiesTask, UpdateDescriptionTask} from "@ploufbag/common";
 
 test("updateDescription success", async () => {
     const input: UpdateDescriptionTask = {

--- a/functions/src/tasks/updateDescription/updateActivityDescription.test.ts
+++ b/functions/src/tasks/updateDescription/updateActivityDescription.test.ts
@@ -1,11 +1,11 @@
 import {afterAll, afterEach, beforeAll, beforeEach, expect, it, test} from "vitest";
 import {TestContainer} from "../../model/database/generateContainer.test";
 import {StartedPostgreSqlContainer} from "@testcontainers/postgresql";
-// `end` is not exported by @parastats/common — it is the local alias for
+// `end` is not exported by @ploufbag/common — it is the local alias for
 // closeAllConnections, re-exported from model/database/client, which is how the
 // other test files import it.
 import {end} from "../../model/database/client";
-import {DescriptionPreference, FlightRow, DescriptionFormatter, withPooledClient} from "@parastats/common";
+import {DescriptionPreference, FlightRow, DescriptionFormatter, withPooledClient} from "@ploufbag/common";
 import {Mocks} from "../../model/database/Mocks.test";
 
 let container: StartedPostgreSqlContainer

--- a/functions/src/tasks/updateDescription/updateActivityDescription.ts
+++ b/functions/src/tasks/updateDescription/updateActivityDescription.ts
@@ -1,4 +1,4 @@
-import {FlightRow} from "@parastats/common";
+import {FlightRow} from "@ploufbag/common";
 import {DescriptionFormatter} from "./DescriptionFormatterAdapter";
 
 

--- a/functions/src/tasks/updateSingleActivity.ts
+++ b/functions/src/tasks/updateSingleActivity.ts
@@ -1,5 +1,5 @@
-import {isSuccess} from "@parastats/common";
-import {UpdateSingleActivityTask, TaskResult} from '@parastats/common';
+import {isSuccess} from "@ploufbag/common";
+import {UpdateSingleActivityTask, TaskResult} from '@ploufbag/common';
 import {Pilots} from '@/database/Pilots';
 import {Flights} from '@/database/Flights';
 import {StravaApi} from '@/stravaApi';

--- a/functions/src/tasks/utils/stravaConverter.ts
+++ b/functions/src/tasks/utils/stravaConverter.ts
@@ -1,4 +1,4 @@
-import {Either, failed, FlightRow, Polyline, success} from '@parastats/common';
+import {Either, failed, FlightRow, Polyline, success} from '@ploufbag/common';
 import { Sites } from '@/database/Sites';
 import { StravaActivity } from '@/stravaApi/model';
 import { decode, LatLngTuple } from '@googlemaps/polyline-codec';

--- a/functions/src/webhooks/handleCode.ts
+++ b/functions/src/webhooks/handleCode.ts
@@ -2,7 +2,7 @@ import {Request, Response} from "express";
 import {StravaAthlete} from "@/stravaApi/model";
 import axios from "axios";
 import {StravaApi} from "@/stravaApi";
-import {withPooledClient, PilotRow} from "@parastats/common";
+import {withPooledClient, PilotRow} from "@ploufbag/common";
 import trigger from "@/tasks/trigger";
 import {sign} from "@/jwt";
 

--- a/functions/src/webhooks/handleStravaEvent.ts
+++ b/functions/src/webhooks/handleStravaEvent.ts
@@ -9,7 +9,7 @@ import {
     withPooledClient,
     Pilots as PilotsCommon,
     isSuccess, isFailure
-} from "@parastats/common";
+} from "@ploufbag/common";
 import { executeUpdateSingleActivityTask } from "../tasks/updateSingleActivity";
 import { executeUpdateDescriptionTask } from "../tasks/updateDescription";
 import { Flights } from "../model/database/Flights";

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -240,7 +240,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@parastats/common@file:../common":
+"@ploufbag/common@file:../common":
   version "0.1.0"
   dependencies:
     axios "^1.13.2"

--- a/site/dev.Dockerfile
+++ b/site/dev.Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY site/package.json .
 COPY site/yarn.lock .
 # Remove common package dependency for development
-RUN sed -i '/"@parastats\/common":/d' package.json
+RUN sed -i '/"@ploufbag\/common":/d' package.json
 RUN yarn install
 
 COPY site/src ./src

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@parastats/common": "file:../common",
+    "@ploufbag/common": "file:../common",
     "axios": "^1.13.2",
     "jose": "^6.1.3",
     "mapbox-gl": "^3.17.0",

--- a/site/src/app/actions/generateDescriptionPreview.ts
+++ b/site/src/app/actions/generateDescriptionPreview.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { DescriptionFormatterClient, type DescriptionPreference } from '@parastats/common';
+import { DescriptionFormatterClient, type DescriptionPreference } from '@ploufbag/common';
 
 export async function generateDescriptionPreview(
     preferences: DescriptionPreference,

--- a/site/src/app/actions/tasks/Task.ts
+++ b/site/src/app/actions/tasks/Task.ts
@@ -1,4 +1,4 @@
-import {StravaActivityId} from "@parastats/common";
+import {StravaActivityId} from "@ploufbag/common";
 
 export type TaskBody = WingActivityTask
 

--- a/site/src/app/actions/updatePreferences.ts
+++ b/site/src/app/actions/updatePreferences.ts
@@ -2,7 +2,7 @@
 
 import { Auth } from "@auth/index";
 import { DescriptionPreferences, type DescriptionPreference } from "@database/descriptionPreferences";
-import { type Failure, isSuccess } from '@parastats/common';
+import { type Failure, isSuccess } from '@ploufbag/common';
 import { revalidatePath } from 'next/cache';
 
 export async function updateDescriptionPreferences(formData: FormData) {

--- a/site/src/app/dashboard/page.tsx
+++ b/site/src/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import {Flights} from "@database/flights";
 import {getPilotWingStats} from "@database/stats";
 import {Sites} from "@database/Sites";
 import {DescriptionPreferences} from "@database/descriptionPreferences";
-import {isSuccess} from "@parastats/common";
+import {isSuccess} from "@ploufbag/common";
 import styles from "@styles/Page.module.css";
 import detailStyles from "@ui/DetailPages.module.css";
 import dashboardStyles from "./Dashboard.module.css";

--- a/site/src/app/flights/[flight_id]/page.tsx
+++ b/site/src/app/flights/[flight_id]/page.tsx
@@ -2,7 +2,7 @@ import {Flights} from "@database/flights";
 import styles from "@styles/Page.module.css";
 import detailStyles from "@ui/DetailPages.module.css";
 import {Stat} from "@ui/stats/model";
-import {StravaActivityId} from "@parastats/common";
+import {StravaActivityId} from "@ploufbag/common";
 import Stats from "@ui/stats/Stats";
 import ViewOnStrava from "@ui/links/ViewOnStrava";
 import ClientOnlyDate from "@ui/ClientOnlyDate";

--- a/site/src/app/sites/[site_slug]/page.tsx
+++ b/site/src/app/sites/[site_slug]/page.tsx
@@ -5,7 +5,7 @@ import {createMetadata} from "@ui/metadata";
 import {Sites} from "@database/Sites";
 import {Flights} from "@database/flights";
 import FlightItem from "@ui/FlightItem";
-import {StravaAthleteId} from "@parastats/common";
+import {StravaAthleteId} from "@ploufbag/common";
 import SiteMap from "@ui/SiteMap";
 import mapStyles from "@ui/FlightMap.module.css";
 import {formatSiteName} from "../../../utils/formatSiteName";

--- a/site/src/data/api/index.ts
+++ b/site/src/data/api/index.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import {Either} from "@model/Either";
-import {Pilot} from "@parastats/common";
+import {Pilot} from "@ploufbag/common";
 
 type BaseResponse = {
     success: boolean

--- a/site/src/data/auth/index.ts
+++ b/site/src/data/auth/index.ts
@@ -1,7 +1,7 @@
 import {failure, Either, success} from "@model/Either";
 import {jwtVerify} from "jose";
 import {cookies} from "next/headers";
-import {StravaAthleteId} from "@parastats/common";
+import {StravaAthleteId} from "@ploufbag/common";
 
 export namespace Auth {
 

--- a/site/src/data/database/Sites.ts
+++ b/site/src/data/database/Sites.ts
@@ -1,6 +1,6 @@
 import {failure, Either, success} from "@model/Either";
 import {getDatabase, withPooledClient} from "./client";
-import {Site, StravaAthleteId} from "@parastats/common";
+import {Site, StravaAthleteId} from "@ploufbag/common";
 
 export type PilotSitesStats = {
     takeoffs: SitesStatsItem[]

--- a/site/src/data/database/client.ts
+++ b/site/src/data/database/client.ts
@@ -5,4 +5,4 @@ export {
   withPooledClient, 
   closeAllConnections,
   type Client 
-} from '@parastats/common';
+} from '@ploufbag/common';

--- a/site/src/data/database/descriptionPreferences.ts
+++ b/site/src/data/database/descriptionPreferences.ts
@@ -1,5 +1,5 @@
 import {withPooledClient} from './client';
-import {createFailure, createSuccess, StravaAthleteId} from '@parastats/common';
+import {createFailure, createSuccess, StravaAthleteId} from '@ploufbag/common';
 import {Either} from "@model/Either";
 
 export type DescriptionPreference = {

--- a/site/src/data/database/flights.ts
+++ b/site/src/data/database/flights.ts
@@ -1,6 +1,6 @@
 import {failure, Either, success} from "@model/Either";
 import {withPooledClient, Client} from "./client";
-import {FlightWithSites, StravaActivityId, StravaAthleteId} from "@parastats/common";
+import {FlightWithSites, StravaActivityId, StravaAthleteId} from "@ploufbag/common";
 
 export namespace Flights {
 

--- a/site/src/data/database/pilots.ts
+++ b/site/src/data/database/pilots.ts
@@ -1,6 +1,6 @@
 import {failure, Either, success} from "@model/Either";
 import {getDatabase, withPooledClient} from "./client";
-import {Pilot} from "@parastats/common";
+import {Pilot} from "@ploufbag/common";
 
 export async function getAll(): Promise<Either<Pilot[]>> {
     return withPooledClient(async (database) => {

--- a/site/src/data/database/stats.ts
+++ b/site/src/data/database/stats.ts
@@ -1,5 +1,5 @@
 import {failure, Either, success} from "@model/Either";
-import {StravaAthleteId} from "@parastats/common";
+import {StravaAthleteId} from "@ploufbag/common";
 import {withPooledClient} from "@database/client";
 
 export type PilotWingStats = {

--- a/site/src/data/model/Pilot.ts
+++ b/site/src/data/model/Pilot.ts
@@ -1,4 +1,4 @@
-import { StravaAthleteId } from '@parastats/common';
+import { StravaAthleteId } from '@ploufbag/common';
 
 export type { StravaAthleteId };
 

--- a/site/src/ui/FlightItem.tsx
+++ b/site/src/ui/FlightItem.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import {FlightWithSites} from "@parastats/common";
+import {FlightWithSites} from "@ploufbag/common";
 import Link from "next/link";
 import Stats from "@ui/stats/Stats";
 import {Stat} from "@ui/stats/model";

--- a/site/src/ui/FlightMap.tsx
+++ b/site/src/ui/FlightMap.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react';
 import mapboxgl from 'mapbox-gl';
-import { Polyline } from '@parastats/common';
+import { Polyline } from '@ploufbag/common';
 import BaseMap from './BaseMap';
 import {formatSiteName} from '../utils/formatSiteName';
 

--- a/site/src/ui/FlightsMap.tsx
+++ b/site/src/ui/FlightsMap.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react';
 import mapboxgl from 'mapbox-gl';
-import { FlightWithSites } from '@parastats/common';
+import { FlightWithSites } from '@ploufbag/common';
 import BaseMap from './BaseMap';
 import {formatSiteName} from '../utils/formatSiteName';
 

--- a/site/src/ui/PilotItem.tsx
+++ b/site/src/ui/PilotItem.tsx
@@ -1,4 +1,4 @@
-import {Pilot} from "@parastats/common";
+import {Pilot} from "@ploufbag/common";
 import Link from "next/link";
 import styles from "./PilotItem.module.css";
 

--- a/site/src/ui/PilotMap.tsx
+++ b/site/src/ui/PilotMap.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react';
 import mapboxgl from 'mapbox-gl';
-import { FlightWithSites } from '@parastats/common';
+import { FlightWithSites } from '@ploufbag/common';
 import BaseMap from './BaseMap';
 import {formatSiteName} from '../utils/formatSiteName';
 

--- a/site/src/ui/SiteItem.tsx
+++ b/site/src/ui/SiteItem.tsx
@@ -1,4 +1,4 @@
-import {Site} from "@parastats/common";
+import {Site} from "@ploufbag/common";
 import Link from "next/link";
 import styles from "./SiteItem.module.css";
 import {formatSiteName} from "../utils/formatSiteName";

--- a/site/src/ui/SiteMap.tsx
+++ b/site/src/ui/SiteMap.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react';
 import mapboxgl from 'mapbox-gl';
-import { FlightWithSites, Site } from '@parastats/common';
+import { FlightWithSites, Site } from '@ploufbag/common';
 import BaseMap from './BaseMap';
 import {formatSiteName} from '../utils/formatSiteName';
 

--- a/site/src/ui/SitesList.tsx
+++ b/site/src/ui/SitesList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import {Site} from "@parastats/common";
+import {Site} from "@ploufbag/common";
 import SiteItem from "@ui/SiteItem";
 import {useState} from "react";
 import styles from "@styles/Page.module.css";

--- a/site/src/ui/links/LandingLink.tsx
+++ b/site/src/ui/links/LandingLink.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import {Site} from "@parastats/common";
+import {Site} from "@ploufbag/common";
 
 export default function LandingLink({landing}: { landing: Site }) {
     return <Link href={`/sites/${landing.slug}`}>↘️ {landing.name}</Link>

--- a/site/src/ui/links/SiteLink.tsx
+++ b/site/src/ui/links/SiteLink.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import {Site} from "@parastats/common";
+import {Site} from "@ploufbag/common";
 import {formatSiteName} from "../../utils/formatSiteName";
 
 export default function SiteLink({site}: { site: Site }) {

--- a/site/src/ui/links/TakeoffLink.tsx
+++ b/site/src/ui/links/TakeoffLink.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import {Site} from "@parastats/common";
+import {Site} from "@ploufbag/common";
 
 export default function TakeoffLink({takeoff}: { takeoff: Site }) {
     return <Link href={`/sites/${takeoff.slug}`}>↗️ {takeoff.name}</Link>

--- a/site/src/ui/links/ViewOnStrava.tsx
+++ b/site/src/ui/links/ViewOnStrava.tsx
@@ -1,4 +1,4 @@
-import {StravaAthleteId, StravaActivityId} from "@parastats/common";
+import {StravaAthleteId, StravaActivityId} from "@ploufbag/common";
 import Link from "next/link";
 import styles from "./Links.module.css"
 

--- a/site/src/ui/links/WingLink.tsx
+++ b/site/src/ui/links/WingLink.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import {StravaAthleteId} from "@parastats/common";
+import {StravaAthleteId} from "@ploufbag/common";
 
 export default function WingLink({wing, pilotId}: { wing: string, pilotId: StravaAthleteId }) {
     return <Link href={`/pilots/${pilotId}/${wing}`}>🪂 {wing}</Link>

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -21,10 +21,10 @@
     "jsx": "react-jsx",
     "incremental": true,
     "paths": {
-      "@parastats/common": [
+      "@ploufbag/common": [
         "../common/src/index.ts"
       ],
-      "@parastats/common/*": [
+      "@ploufbag/common/*": [
         "../common/src/*"
       ],
       "@model/*": [

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       "@database": path.resolve(__dirname, "./src/data/database"),
       "@model": path.resolve(__dirname, "./src/data/model"),
       "@utils": path.resolve(__dirname, "./src/utils"),
-      "@parastats/common": path.resolve(__dirname, "../common/dist"),
+      "@ploufbag/common": path.resolve(__dirname, "../common/dist"),
     }
   },
   test: {

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -483,7 +483,7 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.1.tgz#96e9e335e2577481dab6fc7a2af48f3e4a28fbdb"
   integrity sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==
 
-"@parastats/common@file:../common":
+"@ploufbag/common@file:../common":
   version "0.1.0"
   dependencies:
     axios "^1.13.2"


### PR DESCRIPTION
## Scope

**Step 2 of 3.** Package scope only: `@parastats/*` → `@ploufbag/*`. The repository name follows
in step 3. User-facing copy was step 1 (#24).

85 files. Mechanical, but with a few places where the scope is structural rather than textual.

## Beyond the imports

| Where | What |
|---|---|
| `common/package.json` | the published package `name` |
| `functions/package.json`, `site/package.json` | `file:../common` dependency key |
| `functions/package.prod.json` | `file:./common` — the production bundle's own manifest |
| `site/tsconfig.json` | both path aliases (`@ploufbag/common` and `/*`) |
| `site/vitest.config.ts` | test-time alias to `../common/dist` |
| `functions/dev.Dockerfile`, `site/dev.Dockerfile` | strip the dep, then `mkdir` + `ln -sf` the scope dir by hand |

## The miss worth knowing about

A first pass replacing `@parastats/` left **four references behind**, because they write the scope
with an **escaped slash** inside `sed` programs:

```
RUN sed -i '/"@parastats\/common":/d' package.json
RUN mkdir -p node_modules/@parastats
```

One of those files — `site/dev.Dockerfile` — therefore never appeared in the original file list,
since it contains no unescaped `@parastats/` at all.

These are precisely the lines that rebuild `node_modules` for local development, so the miss
**would not have failed a typecheck, a test, or CI**. It would have surfaced later as a broken
`docker compose up`, at a point where nobody would connect it to a rename. Found by grepping for
the bare name after the rename rather than trusting the first sweep.

## Lock files

Scope-only diffs (7 lines across 4 files). The dependency is `file:`-linked, so there are no
registry integrity hashes to regenerate — the entries are just renamed keys.

## Test plan

- [x] `functions` — `tsc --noEmit`, **0 errors**
- [x] `common` — **16 tests pass**, `yarn build` clean
- [x] `site` — `tsc --noEmit` clean apart from 7 pre-existing errors in
      `app/api/admin/monitoring/stats/route.unit.test.ts` (vitest mock typing, untouched here)
- [x] `functions buildProd` — bundle emits `@ploufbag/common` in both `dist/package.json` and
      `dist/common/package.json`, and contains **no** reference to the old scope
- [x] Fresh `yarn install` in `functions` and `site` resolves `node_modules/@ploufbag/common`
- [ ] Container tests, site build, `docker compose` — delegated to CI (no container runtime here)

> [!NOTE]
> Local installs needed `--ignore-engines`: this machine runs Node 23.1.0 while `.nvmrc` pins 20
> and vitest declares `^20 || ^22 || >=24`. That is a local-environment quirk, not a repo change —
> CI uses Node 20 via `setup-node`, so it installs cleanly there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ya9DbiQmKouVXAinWtkRj
