### PR TITLE
feat: Open signups from the home page, capped at 10, with signup analytics

### DIFF
--- a/common/dist/index.d.ts
+++ b/common/dist/index.d.ts
@@ -1,5 +1,6 @@
 export * from './database';
 export * from './utils';
+export * from './descriptionFooter';
 export * from './DescriptionFormatter';
 export * from './DescriptionFormatterClient';
 export * from './model';

--- a/common/dist/index.js
+++ b/common/dist/index.js
@@ -17,6 +17,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.TaskExecutions = exports.WebhookEvents = exports.DescriptionPreferences = exports.Windsocks = exports.Sites = exports.Flights = exports.Pilots = void 0;
 __exportStar(require("./database"), exports);
 __exportStar(require("./utils"), exports);
+__exportStar(require("./descriptionFooter"), exports);
 __exportStar(require("./DescriptionFormatter"), exports);
 __exportStar(require("./DescriptionFormatterClient"), exports);
 __exportStar(require("./model"), exports);

--- a/functions/src/model/database/scripts/add_created_at_to_pilots.sql
+++ b/functions/src/model/database/scripts/add_created_at_to_pilots.sql
@@ -1,0 +1,19 @@
+-- Gives pilots a signup timestamp, so completed signups can be reported over
+-- the same time window as the landings and signup clicks in analytics_events.
+--
+-- Deliberately left NULL for existing rows rather than backfilled with NOW().
+-- We do not know when those pilots connected, and stamping today's date would
+-- make the funnel read as though they all signed up the day this shipped.
+-- Queries counting signups in a window therefore see NULL rows as "before the
+-- window", which is true of every pilot that predates this column.
+--
+-- No application change is needed to populate it: handleCode's INSERT does not
+-- name created_at, so the default applies on insert, and its ON CONFLICT DO
+-- UPDATE branch does not touch it -- a returning pilot re-authorising keeps
+-- their original signup date.
+
+ALTER TABLE pilots
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE pilots
+    ALTER COLUMN created_at SET DEFAULT NOW();

--- a/functions/src/model/database/scripts/create_analytics_events.sql
+++ b/functions/src/model/database/scripts/create_analytics_events.sql
@@ -1,0 +1,47 @@
+-- Analytics events: how many people land on the site, and how many of them
+-- start a Strava signup.
+--
+-- event_type is VARCHAR + CHECK rather than a Postgres ENUM, deliberately.
+-- ts-postgres cannot decode custom enum OIDs, which is why the monitoring
+-- tables had to be rebuilt once already -- see
+-- migrate_monitoring_tables_to_varchar.sql. An enum here would insert fine and
+-- fail on read.
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS analytics_events
+(
+    id          UUID PRIMARY KEY                  DEFAULT uuid_generate_v4(),
+
+    -- 'landing'      = a request for the home page. The Strava description
+    --                  footer is a bare domain with no path, so a click from
+    --                  Strava is indistinguishable from any other visit to '/';
+    --                  with no other inbound channel, this is the description
+    --                  click proxy. If the footer ever gains a tracked path,
+    --                  add a distinct event type rather than reinterpreting
+    --                  this one -- historical rows would not mean the same thing.
+    -- 'signup_click' = pressed "Connect with Strava", i.e. attempted a signup.
+    --                  Recorded even when we are at capacity, because a click
+    --                  we had to turn away is the demand signal worth having.
+    event_type  VARCHAR(32)              NOT NULL CHECK (event_type IN ('landing', 'signup_click')),
+    occurred_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    -- Salted hash of IP + user agent, rotated daily. Enough to count uniques
+    -- for a day; not enough to identify or track anyone across days, and no raw
+    -- IP is stored. NULL when the hash could not be computed.
+    visitor_id  VARCHAR(64),
+
+    path        VARCHAR(255),
+    referrer    TEXT,
+    user_agent  TEXT,
+
+    -- Crawlers reach '/' constantly and would otherwise dwarf real traffic.
+    -- Stored rather than dropped so the classifier can be revised later against
+    -- the raw rows.
+    is_bot      BOOLEAN                  NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_occurred_at ON analytics_events (occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_event_type ON analytics_events (event_type);
+-- Serves the headline summary query, which always filters humans within a window.
+CREATE INDEX IF NOT EXISTS idx_analytics_events_type_occurred_human ON analytics_events (event_type, occurred_at DESC) WHERE is_bot = FALSE;

--- a/site/src/app/admin/page.tsx
+++ b/site/src/app/admin/page.tsx
@@ -1,15 +1,24 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { WebhookEvent, TaskExecution, MonitoringStats } from '@model/admin';
+import { WebhookEvent, TaskExecution, MonitoringStats, AnalyticsSummary } from '@model/admin';
+import { ATHLETE_CAPACITY } from '@model/signup';
+
+/** Percentage of `total`, or an em dash when there is nothing to divide by. */
+function formatRate(part: number, total: number): string {
+    if (!total) return '—';
+    return `${Math.round((part / total) * 100)}%`;
+}
 
 export default function AdminMonitoringPage() {
     const [stats, setStats] = useState<MonitoringStats | null>(null);
     const [webhooks, setWebhooks] = useState<WebhookEvent[]>([]);
     const [tasks, setTasks] = useState<TaskExecution[]>([]);
+    const [analytics, setAnalytics] = useState<AnalyticsSummary | null>(null);
+    const [analyticsError, setAnalyticsError] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    const [activeTab, setActiveTab] = useState<'overview' | 'webhooks' | 'tasks'>('overview');
+    const [activeTab, setActiveTab] = useState<'overview' | 'analytics' | 'webhooks' | 'tasks'>('overview');
 
     useEffect(() => {
         fetchMonitoringData();
@@ -43,6 +52,21 @@ export default function AdminMonitoringPage() {
             setStats(statsData);
             setWebhooks(webhooksData.webhooks);
             setTasks(tasksData.tasks);
+
+            // Fetched separately and never allowed to fail the page. Analytics
+            // depends on a table that is applied by hand (see
+            // create_analytics_events.sql); until that migration is run the
+            // route 500s, and webhook/task monitoring is more important than
+            // the signup funnel.
+            try {
+                const analyticsRes = await fetch('/api/admin/analytics?hours=168');
+                if (!analyticsRes.ok) throw new Error(`HTTP ${analyticsRes.status}`);
+                setAnalytics(await analyticsRes.json());
+                setAnalyticsError(null);
+            } catch (analyticsErr) {
+                setAnalytics(null);
+                setAnalyticsError(analyticsErr instanceof Error ? analyticsErr.message : 'Unknown error');
+            }
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Unknown error');
         } finally {
@@ -180,6 +204,7 @@ export default function AdminMonitoringPage() {
                     <nav className="-mb-px flex space-x-8">
                         {[
                             { id: 'overview', label: 'Overview' },
+                            { id: 'analytics', label: 'Analytics' },
                             { id: 'webhooks', label: 'Webhooks' },
                             { id: 'tasks', label: 'Tasks' }
                         ].map((tab) => (
@@ -197,6 +222,83 @@ export default function AdminMonitoringPage() {
                         ))}
                     </nav>
                 </div>
+
+                {/* Analytics Tab */}
+                {activeTab === 'analytics' && (
+                    <div className="space-y-8">
+                        {analyticsError && (
+                            <div className="bg-yellow-50 border border-yellow-200 rounded-md p-4 text-sm text-yellow-800">
+                                <p className="font-medium">Analytics unavailable: {analyticsError}</p>
+                                <p className="mt-1">
+                                    If this is the first deploy, apply
+                                    <code className="mx-1 px-1 bg-yellow-100 rounded">
+                                        functions/src/model/database/scripts/create_analytics_events.sql
+                                    </code>
+                                    and
+                                    <code className="mx-1 px-1 bg-yellow-100 rounded">
+                                        add_created_at_to_pilots.sql
+                                    </code>
+                                    to the database.
+                                </p>
+                            </div>
+                        )}
+
+                        {analytics && (
+                            <>
+                                <div>
+                                    <h2 className="text-lg font-medium text-gray-900">Signup funnel</h2>
+                                    <p className="mt-1 text-sm text-gray-500">
+                                        Last {analytics.period_hours} hours. Landings are home page visits;
+                                        the Strava description footer is a bare domain, so every click from
+                                        an activity arrives here indistinguishable from direct traffic.
+                                        Bots excluded.
+                                    </p>
+                                </div>
+
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                                    <div className="bg-white overflow-hidden shadow rounded-lg p-5">
+                                        <dt className="text-sm font-medium text-gray-500 truncate">Landings</dt>
+                                        <dd className="text-3xl font-semibold text-gray-900">{analytics.unique_landings}</dd>
+                                        <div className="mt-2 text-sm text-gray-500">
+                                            {analytics.landings} views &middot; {analytics.bot_landings} bot
+                                        </div>
+                                    </div>
+
+                                    <div className="bg-white overflow-hidden shadow rounded-lg p-5">
+                                        <dt className="text-sm font-medium text-gray-500 truncate">Signup attempts</dt>
+                                        <dd className="text-3xl font-semibold text-gray-900">{analytics.unique_signup_clicks}</dd>
+                                        <div className="mt-2 text-sm text-gray-500">
+                                            {analytics.signup_clicks} clicks &middot; {formatRate(analytics.unique_signup_clicks, analytics.unique_landings)} of landings
+                                        </div>
+                                    </div>
+
+                                    <div className="bg-white overflow-hidden shadow rounded-lg p-5">
+                                        <dt className="text-sm font-medium text-gray-500 truncate">Signups completed</dt>
+                                        <dd className="text-3xl font-semibold text-gray-900">{analytics.signups_completed}</dd>
+                                        <div className="mt-2 text-sm text-gray-500">
+                                            {formatRate(analytics.signups_completed, analytics.unique_signup_clicks)} of attempts
+                                        </div>
+                                    </div>
+
+                                    <div className="bg-white overflow-hidden shadow rounded-lg p-5">
+                                        <dt className="text-sm font-medium text-gray-500 truncate">Capacity</dt>
+                                        <dd className="text-3xl font-semibold text-gray-900">
+                                            {analytics.pilots_total}<span className="text-lg text-gray-400">/{ATHLETE_CAPACITY}</span>
+                                        </dd>
+                                        <div className="mt-2 text-sm text-gray-500">
+                                            {Math.max(0, ATHLETE_CAPACITY - analytics.pilots_total)} spots left
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <p className="text-sm text-gray-500">
+                                    Pilots who connected before signup timestamps were recorded have no
+                                    created_at and are counted in Capacity but never in Signups completed.
+                                </p>
+                            </>
+                        )}
+                    </div>
+                )}
 
                 {/* Overview Tab */}
                 {activeTab === 'overview' && stats && (

--- a/site/src/app/api/admin/analytics/route.ts
+++ b/site/src/app/api/admin/analytics/route.ts
@@ -1,0 +1,23 @@
+import {NextRequest, NextResponse} from 'next/server';
+import {getAnalyticsSummary} from '@database/analytics';
+
+export const dynamic = 'force-dynamic';
+
+/** A year. Anything larger is a typo, not a question anyone is asking. */
+const MAX_PERIOD_HOURS = 24 * 365;
+
+export async function GET(request: NextRequest) {
+    const hoursParam = new URL(request.url).searchParams.get('hours');
+    const periodHours = hoursParam ? parseInt(hoursParam) : 24;
+
+    if (isNaN(periodHours) || periodHours <= 0 || periodHours > MAX_PERIOD_HOURS) {
+        return NextResponse.json({error: 'Invalid hours parameter'}, {status: 400});
+    }
+
+    try {
+        return NextResponse.json(await getAnalyticsSummary(periodHours));
+    } catch (error) {
+        console.error('Error fetching analytics summary:', error);
+        return NextResponse.json({error: 'Internal server error'}, {status: 500});
+    }
+}

--- a/site/src/app/api/admin/analytics/route.unit.test.ts
+++ b/site/src/app/api/admin/analytics/route.unit.test.ts
@@ -1,0 +1,71 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {NextRequest} from 'next/server';
+
+vi.mock('@database/analytics', () => ({
+    getAnalyticsSummary: vi.fn()
+}));
+
+const SUMMARY = {
+    period_hours: 24,
+    landings: 12,
+    unique_landings: 9,
+    signup_clicks: 3,
+    unique_signup_clicks: 2,
+    signups_completed: 1,
+    pilots_total: 4,
+    bot_landings: 87,
+};
+
+async function callRoute(query: string = '') {
+    const {GET} = await import('./route');
+    return GET(new NextRequest(`http://localhost:3000/api/admin/analytics${query}`));
+}
+
+describe('/api/admin/analytics - Unit Tests', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('returns the summary and defaults to a 24 hour window', async () => {
+        const {getAnalyticsSummary} = await import('@database/analytics');
+        vi.mocked(getAnalyticsSummary).mockResolvedValue(SUMMARY);
+
+        const response = await callRoute();
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual(SUMMARY);
+        expect(getAnalyticsSummary).toHaveBeenCalledWith(24);
+    });
+
+    it('passes an explicit hours parameter through', async () => {
+        const {getAnalyticsSummary} = await import('@database/analytics');
+        vi.mocked(getAnalyticsSummary).mockResolvedValue({...SUMMARY, period_hours: 168});
+
+        await callRoute('?hours=168');
+
+        expect(getAnalyticsSummary).toHaveBeenCalledWith(168);
+    });
+
+    it.each([
+        ['?hours=0', 'zero'],
+        ['?hours=-5', 'negative'],
+        ['?hours=abc', 'non-numeric'],
+        ['?hours=99999', 'beyond a year'],
+    ])('rejects %s (%s) without querying', async (query) => {
+        const {getAnalyticsSummary} = await import('@database/analytics');
+
+        const response = await callRoute(query);
+
+        expect(response.status).toBe(400);
+        expect(getAnalyticsSummary).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 when the query fails', async () => {
+        const {getAnalyticsSummary} = await import('@database/analytics');
+        vi.mocked(getAnalyticsSummary).mockRejectedValue(new Error('relation "analytics_events" does not exist'));
+
+        const response = await callRoute();
+
+        expect(response.status).toBe(500);
+    });
+});

--- a/site/src/app/connect/route.ts
+++ b/site/src/app/connect/route.ts
@@ -1,0 +1,40 @@
+import {NextRequest, NextResponse} from "next/server";
+import {recordEvent} from "@database/analytics";
+import {getCount} from "@database/pilots";
+import {STRAVA_AUTHORIZE_URL, signupState} from "@model/signup";
+
+/**
+ * The signup entry point. Every "Connect with Strava" button links here rather
+ * than to strava.com directly, for two reasons:
+ *
+ *  - it is the one place a signup attempt can be recorded reliably. A
+ *    client-side beacon fired on click races the navigation away from the page
+ *    and loses events non-deterministically; a server round-trip cannot.
+ *  - it is the one place the capacity gate can actually be enforced, rather
+ *    than merely displayed.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+    // Recorded before the capacity check on purpose: someone we had to turn
+    // away still tried to sign up, and that is the demand signal worth having.
+    await recordEvent('signup_click', '/connect', request.headers);
+
+    let isOpen: boolean;
+    try {
+        isOpen = signupState(await getCount()).isOpen;
+    } catch (error) {
+        // Fail open. Strava enforces the real athlete cap at its own authorize
+        // step, so the worst case is a visitor seeing Strava's error instead of
+        // ours -- strictly better than our database being down meaning nobody
+        // can sign up at all.
+        console.error('connect: capacity check failed, allowing through:', error);
+        isOpen = true;
+    }
+
+    if (!isOpen) {
+        return NextResponse.redirect(new URL('/?full=1', request.url), 302);
+    }
+
+    return NextResponse.redirect(STRAVA_AUTHORIZE_URL, 302);
+}

--- a/site/src/app/connect/route.unit.test.ts
+++ b/site/src/app/connect/route.unit.test.ts
@@ -1,0 +1,65 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {NextRequest} from 'next/server';
+import {ATHLETE_CAPACITY, STRAVA_AUTHORIZE_URL} from '@model/signup';
+
+vi.mock('@database/analytics', () => ({
+    recordEvent: vi.fn()
+}));
+
+vi.mock('@database/pilots', () => ({
+    getCount: vi.fn()
+}));
+
+async function callConnect() {
+    const {GET} = await import('./route');
+    return GET(new NextRequest('https://ploufbag.com/connect'));
+}
+
+describe('/connect - Unit Tests', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('sends an athlete to Strava when there are spots left', async () => {
+        const {getCount} = await import('@database/pilots');
+        vi.mocked(getCount).mockResolvedValue(ATHLETE_CAPACITY - 1);
+
+        const response = await callConnect();
+
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe(STRAVA_AUTHORIZE_URL);
+    });
+
+    it('sends an athlete home when at capacity', async () => {
+        const {getCount} = await import('@database/pilots');
+        vi.mocked(getCount).mockResolvedValue(ATHLETE_CAPACITY);
+
+        const response = await callConnect();
+
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe('https://ploufbag.com/?full=1');
+    });
+
+    it('records the attempt even when turned away at capacity', async () => {
+        // The whole point of tracking: a click we had to refuse is still demand.
+        const {getCount} = await import('@database/pilots');
+        const {recordEvent} = await import('@database/analytics');
+        vi.mocked(getCount).mockResolvedValue(ATHLETE_CAPACITY);
+
+        await callConnect();
+
+        expect(recordEvent).toHaveBeenCalledWith('signup_click', '/connect', expect.anything());
+    });
+
+    it('fails open to Strava when the capacity check throws', async () => {
+        // Strava enforces the real cap anyway, so a database outage must not be
+        // the reason nobody can sign up.
+        const {getCount} = await import('@database/pilots');
+        vi.mocked(getCount).mockRejectedValue(new Error('connection refused'));
+
+        const response = await callConnect();
+
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe(STRAVA_AUTHORIZE_URL);
+    });
+});

--- a/site/src/app/login/page.tsx
+++ b/site/src/app/login/page.tsx
@@ -2,10 +2,27 @@ import styles from "@styles/Page.module.css";
 import {Metadata} from "next";
 import {createMetadata} from "@ui/metadata";
 import {BRAND_NAME} from "@ui/brand";
+import ConnectWithStrava from "@ui/ConnectWithStrava";
+import {getCount} from "@database/pilots";
+import {signupState} from "@model/signup";
 
 export const metadata: Metadata = createMetadata('Login')
 
-export default function Login() {
+/**
+ * Reads the live pilot count for the capacity gate, so it must not be cached
+ * into a page that keeps offering a full signup.
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function Login() {
+    // Fail open, matching / and /connect: a database blip should not hide the
+    // only way in. Strava still enforces the real athlete cap.
+    const pilotCount = await getCount().catch(error => {
+        console.error('login: pilot count failed, showing signup anyway:', error);
+        return 0;
+    });
+    const state = signupState(pilotCount);
+
     return <div className={styles.loginPageContainer}>
         <div className={styles.loginContent}>
             <div style={{ marginBottom: 'var(--space-6)' }}>
@@ -109,13 +126,21 @@ export default function Login() {
             </div>
 
             <div style={{ marginBottom: 'var(--space-6)' }}>
-                <a className={styles.stravaButton}
-                   href="https://www.strava.com/oauth/authorize?client_id=155420&redirect_uri=https%3A%2F%2Fwebhooks.ploufbag.com&response_type=code&approval_prompt=force&scope=read_all,activity:write,activity:read_all">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.599h4.172L10.463 0l-7 13.828h4.172"/>
-                    </svg>
-                    Connect with Strava
-                </a>
+                {state.isOpen
+                    ? <>
+                        <ConnectWithStrava/>
+                        <p className={styles.description}
+                           style={{ fontSize: 'var(--font-size-sm)', marginTop: 'var(--space-3)', marginBottom: 0 }}>
+                            Early access &mdash; {state.spotsRemaining} of {state.capacity} spots left.
+                        </p>
+                    </>
+                    : <div className={`${styles.alert} ${styles.alertWarning}`}>
+                        <strong>All {state.capacity} spots are taken.</strong>
+                        <p style={{ margin: 'var(--space-2) 0 0 0' }}>
+                            Strava caps how many athletes can connect to {BRAND_NAME} while it is in
+                            early access. Check back once the cap is raised.
+                        </p>
+                    </div>}
             </div>
 
             <div className={styles.loginFeatures}>

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,8 +1,57 @@
-import Head from "next/head";
+import {headers} from "next/headers";
 import styles from "@styles/Page.module.css";
 import {BRAND_NAME} from "@ui/brand";
+import ConnectWithStrava from "@ui/ConnectWithStrava";
+import {recordEvent} from "@database/analytics";
+import {getCount} from "@database/pilots";
+import {SignupState, signupState} from "@model/signup";
 
-export default function Home() {
+/**
+ * Never statically rendered: this page both records a landing event and reads
+ * the live pilot count for the capacity gate. Cached, it would report one
+ * visitor for all time and go stale the moment a pilot signs up.
+ */
+export const dynamic = 'force-dynamic';
+
+type SearchParams = { full?: string };
+
+function SpotsRemaining({state}: { state: SignupState }) {
+    if (!state.isOpen) {
+        return <div className={`${styles.alert} ${styles.alertWarning}`}>
+            <strong>All {state.capacity} spots are taken.</strong>
+            <p style={{margin: 'var(--space-2) 0 0 0'}}>
+                {BRAND_NAME} is in early access and Strava caps how many athletes can connect to
+                it. Check back once the cap is raised.
+            </p>
+        </div>
+    }
+
+    return <p className={styles.description} style={{marginBottom: 'var(--space-4)'}}>
+        Early access &mdash; <strong>{state.spotsRemaining} of {state.capacity}</strong> spots left.
+    </p>
+}
+
+export default async function Home({searchParams}: { searchParams: Promise<SearchParams> }) {
+    const headersList = await headers();
+
+    // Both are awaited before render. The landing insert is a few milliseconds
+    // against a warm pool, and doing it inline is more reliable on Cloud Run
+    // than deferring it past the response, where CPU is throttled.
+    const [, pilotCount] = await Promise.all([
+        recordEvent('landing', '/', headersList),
+        getCount().catch(error => {
+            // Fail open, matching /connect: a database blip should not make the
+            // site look closed. Strava still enforces the real cap.
+            console.error('home: pilot count failed, showing signup anyway:', error);
+            return 0;
+        }),
+    ]);
+
+    const state = signupState(pilotCount);
+    // Set when /connect turned someone away, so the explanation lands on the
+    // page they arrive at rather than being silently swallowed by the redirect.
+    const wasTurnedAway = (await searchParams).full !== undefined;
+
     return (
         <div className={styles.pageCentered}>
 
@@ -10,7 +59,49 @@ export default function Home() {
                 Welcome to {BRAND_NAME}.
             </h1>
 
-            <h2 className={styles.subtitle}>Coming soon...</h2>
+            <h2 className={styles.subtitle}>
+                Your paragliding flights, tracked from Strava.
+            </h2>
+
+            <p className={styles.description}>
+                Connect your Strava account and {BRAND_NAME} finds your flights, works out where you
+                took off and landed, and writes the stats straight back onto your activity.
+            </p>
+
+            {wasTurnedAway && !state.isOpen && (
+                <div className={`${styles.alert} ${styles.alertWarning}`}>
+                    Someone took the last spot before you got there. Sorry.
+                </div>
+            )}
+
+            <SpotsRemaining state={state}/>
+
+            {state.isOpen && (
+                <div style={{marginBottom: 'var(--space-6)'}}>
+                    <ConnectWithStrava/>
+                </div>
+            )}
+
+            <div className={styles.loginFeatures}>
+                <h3 style={{
+                    marginBottom: 'var(--space-3)',
+                    fontSize: 'var(--font-size-base)',
+                    fontWeight: 'var(--font-weight-semibold)'
+                }}>
+                    What you'll get:
+                </h3>
+                <ul style={{
+                    margin: 0,
+                    paddingLeft: 'var(--space-4)',
+                    color: 'var(--color-text-secondary)',
+                    fontSize: 'var(--font-size-sm)'
+                }}>
+                    <li style={{marginBottom: 'var(--space-1)'}}>Automatic flight detection</li>
+                    <li style={{marginBottom: 'var(--space-1)'}}>Takeoff and landing site identification</li>
+                    <li style={{marginBottom: 'var(--space-1)'}}>Wind conditions at the time you flew</li>
+                    <li>Flight stats written back to your Strava description</li>
+                </ul>
+            </div>
 
         </div>
     );

--- a/site/src/data/database/analytics.ts
+++ b/site/src/data/database/analytics.ts
@@ -1,0 +1,133 @@
+import {createHash} from "crypto";
+import {withPooledClient} from "@database/client";
+import {isBotUserAgent} from "@utils/isBot";
+
+export type AnalyticsEventType = 'landing' | 'signup_click';
+
+/**
+ * A request's headers, narrowed to what we read. Both `headers()` from
+ * next/headers (server components) and `request.headers` (route handlers)
+ * satisfy this, so one recorder serves both.
+ */
+export type HeaderReader = { get(name: string): string | null };
+
+export type AnalyticsSummary = {
+    period_hours: number;
+    /** Home page views, excluding anything classified as a bot. */
+    landings: number;
+    unique_landings: number;
+    /** "Connect with Strava" presses, including any turned away at capacity. */
+    signup_clicks: number;
+    unique_signup_clicks: number;
+    /** Pilots whose created_at falls in the window. NULL created_at predates the column. */
+    signups_completed: number;
+    /** All pilots ever, i.e. the number the capacity gate compares against. */
+    pilots_total: number;
+    bot_landings: number;
+};
+
+/**
+ * Daily-rotating pseudonymous visitor id.
+ *
+ * We want "how many people", not "how many requests", but we do not want to
+ * store IP addresses. Hashing IP + user agent with a per-day salt gives a token
+ * that dedupes within a day and is useless for following anyone across days.
+ *
+ * SESSION_SECRET is reused as the salt purely because the site already has it;
+ * if it is unset the hash is still computed, it is just not secret -- which is
+ * acceptable for a counter, and better than dropping the row.
+ */
+function visitorIdFor(headers: HeaderReader, now: Date): string {
+    const forwardedFor = headers.get('x-forwarded-for');
+    // Cloud Run appends its own hops; the client is the first entry.
+    const ip = forwardedFor?.split(',')[0]?.trim()
+        || headers.get('x-real-ip')
+        || 'unknown';
+    const userAgent = headers.get('user-agent') || 'unknown';
+    const day = now.toISOString().slice(0, 10);
+    const salt = process.env.SESSION_SECRET || 'ploufbag-analytics';
+
+    return createHash('sha256')
+        .update(`${ip}|${userAgent}|${day}|${salt}`)
+        .digest('hex')
+        .slice(0, 64);
+}
+
+/**
+ * Records one event. Never throws.
+ *
+ * Analytics is strictly a side observation of a page render -- a failed insert,
+ * an unmigrated database, or a slow pool must never be the reason a visitor
+ * sees an error instead of the signup button. Failures are logged and swallowed.
+ */
+export async function recordEvent(
+    eventType: AnalyticsEventType,
+    path: string,
+    headers: HeaderReader,
+): Promise<void> {
+    try {
+        const userAgent = headers.get('user-agent');
+        const now = new Date();
+
+        await withPooledClient(async (database) => {
+            await database.query(`
+                insert into analytics_events (event_type, visitor_id, path, referrer, user_agent, is_bot)
+                values ($1, $2, $3, $4, $5, $6)
+            `, [
+                eventType,
+                visitorIdFor(headers, now),
+                path.slice(0, 255),
+                headers.get('referer'),
+                userAgent,
+                isBotUserAgent(userAgent),
+            ]);
+        });
+    } catch (error) {
+        console.error(`recordEvent(${eventType}) failed, continuing:`, error);
+    }
+}
+
+/**
+ * The funnel over a window: landings -> signup clicks -> completed signups.
+ *
+ * `periodHours` is passed as a bind parameter into make_interval rather than
+ * interpolated into the SQL string.
+ */
+export async function getAnalyticsSummary(periodHours: number): Promise<AnalyticsSummary> {
+    return withPooledClient(async (database) => {
+        type EventCounts = {
+            landings: number;
+            unique_landings: number;
+            signup_clicks: number;
+            unique_signup_clicks: number;
+            bot_landings: number;
+        };
+
+        const events = await database.query<EventCounts>(`
+            select count(1) filter (where event_type = 'landing' and not is_bot)::int                       as landings,
+                   count(distinct visitor_id) filter (where event_type = 'landing' and not is_bot)::int     as unique_landings,
+                   count(1) filter (where event_type = 'signup_click' and not is_bot)::int                  as signup_clicks,
+                   count(distinct visitor_id) filter (where event_type = 'signup_click' and not is_bot)::int as unique_signup_clicks,
+                   count(1) filter (where event_type = 'landing' and is_bot)::int                           as bot_landings
+            from analytics_events
+            where occurred_at > now() - make_interval(hours => $1::int)
+        `, [periodHours]);
+
+        type PilotCounts = {
+            signups_completed: number;
+            pilots_total: number;
+        };
+
+        const pilots = await database.query<PilotCounts>(`
+            select count(1) filter (where created_at > now() - make_interval(hours => $1::int))::int as signups_completed,
+                   count(1)::int                                                               as pilots_total
+            from pilots
+        `, [periodHours]);
+
+        return {
+            period_hours: periodHours,
+            ...events.rows[0].reify(),
+            ...pilots.rows[0].reify(),
+        };
+    });
+}

--- a/site/src/data/database/pilots.ts
+++ b/site/src/data/database/pilots.ts
@@ -15,6 +15,20 @@ export async function getAll(): Promise<Either<Pilot[]>> {
     });
 }
 
+/**
+ * Number of connected pilots, which is what the signup capacity gate compares
+ * against. Counted rather than derived from getAll() so the gate does not pull
+ * every pilot row on every home page render.
+ */
+export async function getCount(): Promise<number> {
+    return withPooledClient(async (database) => {
+        const result = await database.query<{ count: number }>(`
+            select count(1)::int as count
+            from pilots`)
+        return result.rows[0].reify().count
+    });
+}
+
 export async function get(pilotId: number): Promise<Either<Pilot>> {
     return withPooledClient(async (database) => {
         const result = await database.query<Pilot>(`

--- a/site/src/data/model/admin.ts
+++ b/site/src/data/model/admin.ts
@@ -25,6 +25,22 @@ export interface TaskExecution {
     retry_count: number;
 }
 
+/**
+ * Mirrors AnalyticsSummary in src/data/database/analytics.ts, which is where
+ * the field docs live. Restated here because this module is imported by the
+ * client-side admin page and must not pull in the database layer.
+ */
+export interface AnalyticsSummary {
+    period_hours: number;
+    landings: number;
+    unique_landings: number;
+    signup_clicks: number;
+    unique_signup_clicks: number;
+    signups_completed: number;
+    pilots_total: number;
+    bot_landings: number;
+}
+
 export interface MonitoringStats {
     period_hours: number;
     webhooks: {

--- a/site/src/data/model/signup.test.ts
+++ b/site/src/data/model/signup.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'vitest';
+import {ATHLETE_CAPACITY, STRAVA_AUTHORIZE_URL, signupState} from './signup';
+
+describe('signupState', () => {
+    it('is open with spots left below capacity', () => {
+        expect(signupState(0)).toEqual({
+            isOpen: true,
+            pilotCount: 0,
+            capacity: ATHLETE_CAPACITY,
+            spotsRemaining: ATHLETE_CAPACITY,
+        });
+
+        expect(signupState(1).spotsRemaining).toBe(ATHLETE_CAPACITY - 1);
+        expect(signupState(ATHLETE_CAPACITY - 1).isOpen).toBe(true);
+    });
+
+    it('closes exactly at capacity', () => {
+        const state = signupState(ATHLETE_CAPACITY);
+        expect(state.isOpen).toBe(false);
+        expect(state.spotsRemaining).toBe(0);
+    });
+
+    it('never reports negative spots when over capacity', () => {
+        // Strava should prevent this, but a manually inserted pilot or a raised
+        // cap on Strava's side without a code change would get us here, and
+        // spotsRemaining is rendered directly.
+        const state = signupState(ATHLETE_CAPACITY + 5);
+        expect(state.isOpen).toBe(false);
+        expect(state.spotsRemaining).toBe(0);
+    });
+});
+
+describe('STRAVA_AUTHORIZE_URL', () => {
+    it('is byte-identical to the URL previously inlined in the login page', () => {
+        // Pinned deliberately. This URL is one that Strava currently accepts;
+        // percent-encoding the scope separators or changing the redirect_uri
+        // would be a silent behaviour change that only shows up as a rejected
+        // OAuth request in production.
+        expect(STRAVA_AUTHORIZE_URL).toBe(
+            'https://www.strava.com/oauth/authorize' +
+            '?client_id=155420' +
+            '&redirect_uri=https%3A%2F%2Fwebhooks.ploufbag.com' +
+            '&response_type=code' +
+            '&approval_prompt=force' +
+            '&scope=read_all,activity:write,activity:read_all'
+        );
+    });
+});

--- a/site/src/data/model/signup.ts
+++ b/site/src/data/model/signup.ts
@@ -1,0 +1,60 @@
+/**
+ * Signup capacity, and the one place the Strava OAuth URL is built.
+ *
+ * The cap is not ours to choose. Strava enforces an athlete capacity per API
+ * application: new apps start at 1 ("single player mode"), a self-serve upgrade
+ * in the API dashboard raises it to 10, and anything beyond that needs an
+ * approved Developer Program request. This app is on the self-serve tier.
+ *
+ * Strava rejects athlete number 11 at its own /oauth/authorize step, before any
+ * code reaches our webhooks service, so ATHLETE_CAPACITY does not *create* the
+ * limit -- it just lets us stop offering a button Strava would refuse, and show
+ * how many spots are left instead. Raising this number alone therefore does not
+ * open more signups; it only re-exposes a button that then fails on Strava's
+ * side. Get the capacity increase approved first, then change this.
+ */
+export const ATHLETE_CAPACITY = 10;
+
+const STRAVA_CLIENT_ID = "155420";
+
+/**
+ * The webhooks service, which handles the `code` callback in handleCode.ts.
+ * Must stay byte-identical to the "Authorization Callback Domain" configured in
+ * the Strava API settings dashboard, or Strava rejects the authorize request.
+ */
+const OAUTH_REDIRECT_URI = "https://webhooks.ploufbag.com";
+
+const OAUTH_SCOPE = "read_all,activity:write,activity:read_all";
+
+/**
+ * Assembled by concatenation rather than URLSearchParams on purpose: this
+ * reproduces the string that was previously inlined in the login page exactly,
+ * including the unescaped commas and colons in `scope`. URLSearchParams would
+ * percent-encode those, which is a change to a URL that currently works.
+ */
+export const STRAVA_AUTHORIZE_URL =
+    `https://www.strava.com/oauth/authorize` +
+    `?client_id=${STRAVA_CLIENT_ID}` +
+    `&redirect_uri=${encodeURIComponent(OAUTH_REDIRECT_URI)}` +
+    `&response_type=code` +
+    `&approval_prompt=force` +
+    `&scope=${OAUTH_SCOPE}`;
+
+export type SignupState = {
+    /** Whether we should be offering the Strava button at all. */
+    isOpen: boolean;
+    pilotCount: number;
+    capacity: number;
+    /** Never negative, so it is safe to render directly. */
+    spotsRemaining: number;
+};
+
+export function signupState(pilotCount: number): SignupState {
+    const spotsRemaining = Math.max(0, ATHLETE_CAPACITY - pilotCount);
+    return {
+        isOpen: spotsRemaining > 0,
+        pilotCount,
+        capacity: ATHLETE_CAPACITY,
+        spotsRemaining,
+    };
+}

--- a/site/src/ui/ConnectWithStrava.tsx
+++ b/site/src/ui/ConnectWithStrava.tsx
@@ -1,0 +1,18 @@
+import styles from "@styles/Page.module.css";
+
+/**
+ * The signup button, in one place so the home page and the login page cannot
+ * drift apart.
+ *
+ * Points at our own /connect route rather than strava.com: that round-trip is
+ * what records the signup attempt and enforces the capacity gate. See
+ * src/app/connect/route.ts.
+ */
+export default function ConnectWithStrava() {
+    return <a className={styles.stravaButton} href="/connect">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.599h4.172L10.463 0l-7 13.828h4.172"/>
+        </svg>
+        Connect with Strava
+    </a>
+}

--- a/site/src/utils/isBot.test.ts
+++ b/site/src/utils/isBot.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'vitest';
+import {isBotUserAgent} from './isBot';
+
+describe('isBotUserAgent', () => {
+    it('treats real browser user agents as human', () => {
+        const browsers = [
+            // Desktop Chrome
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            // iOS Safari, which is what a click from the Strava mobile app opens
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1',
+            // Android Chrome
+            'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0',
+        ];
+
+        for (const userAgent of browsers) {
+            expect(isBotUserAgent(userAgent), userAgent).toBe(false);
+        }
+    });
+
+    it('flags crawlers, scripts and monitors', () => {
+        const bots = [
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+            'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+            'curl/8.4.0',
+            'python-requests/2.31.0',
+            'Go-http-client/2.0',
+            'HeadlessChrome/120.0.0.0',
+            'GoogleStackdriverMonitoring-UptimeChecks',
+        ];
+
+        for (const userAgent of bots) {
+            expect(isBotUserAgent(userAgent), userAgent).toBe(true);
+        }
+    });
+
+    it('treats a missing user agent as a bot', () => {
+        // Every real browser sends one, so an absent header is a script or probe.
+        expect(isBotUserAgent(null)).toBe(true);
+        expect(isBotUserAgent(undefined)).toBe(true);
+        expect(isBotUserAgent('')).toBe(true);
+    });
+
+    it('matches case-insensitively', () => {
+        expect(isBotUserAgent('SomeCrawlerBot/1.0')).toBe(true);
+        expect(isBotUserAgent('CURL/8.4.0')).toBe(true);
+    });
+});

--- a/site/src/utils/isBot.ts
+++ b/site/src/utils/isBot.ts
@@ -1,0 +1,28 @@
+/**
+ * Crude user-agent classifier for analytics.
+ *
+ * The home page is the landing target for the domain stamped on every Strava
+ * activity description, so it is also the page crawlers hit hardest. Without
+ * this, bot traffic would dwarf the handful of real visits we are trying to
+ * count and the numbers would be worthless.
+ *
+ * Deliberately crude: it errs towards marking things as bots, since an
+ * undercounted landing is a much cheaper mistake than a signup funnel that
+ * reads as busy when nobody came. The classification is stored per row rather
+ * than used to drop the row, so it can be revised later against real data.
+ */
+const BOT_PATTERNS = [
+    'bot', 'crawl', 'spider', 'slurp', 'scrape',
+    'curl', 'wget', 'python-requests', 'go-http-client', 'node-fetch', 'axios',
+    'headless', 'phantomjs', 'puppeteer', 'playwright', 'lighthouse',
+    'monitor', 'uptime', 'pingdom', 'preview', 'fetcher', 'validator',
+];
+
+export function isBotUserAgent(userAgent: string | null | undefined): boolean {
+    if (!userAgent) {
+        // Real browsers always send one. A missing UA is a script or a probe.
+        return true;
+    }
+    const normalised = userAgent.toLowerCase();
+    return BOT_PATTERNS.some(pattern => normalised.includes(pattern));
+}


### PR DESCRIPTION
## What

Opens signups from the home page, capped at the 10 athletes Strava currently allows this API application, and adds first-party analytics for the two numbers asked for: how many people land on the site from the Strava description footer, and how many of them try to sign up.

## Why the cap is 10

Strava enforces an athlete capacity per API application. New apps start at 1 ("single player mode"); the self-serve upgrade in the API dashboard raises it to 10; anything beyond needs an approved Developer Program request. This app is on the self-serve tier, so Strava rejects athlete 11 at its own `/oauth/authorize` step, before any code reaches `handleCode`.

`ATHLETE_CAPACITY` therefore **does not create the limit** — it stops us offering a button Strava would refuse, and shows how many spots are left. Bumping the constant alone just re-exposes a button that then fails on Strava's side.

## Changes

**Signups**
- Home page replaces "Coming soon..." with the Strava button, a spots-remaining counter, and a closed state at capacity.
- Every button now points at a new `/connect` route instead of `strava.com` directly. The server round-trip is the only place a signup attempt can be recorded without racing the navigation away, and the only place the gate is enforced rather than displayed.
- The OAuth URL moves out of the login page markup into one constant, pinned byte-for-byte by a test. `URLSearchParams` would percent-encode the `scope` separators — a silent change to a URL Strava currently accepts.
- `/`, `/login` and `/connect` all **fail open** if the pilot-count query fails. A database blip making the site look closed is worse than letting someone through to the cap Strava enforces anyway.

**Analytics**
- New `analytics_events` table: `landing` (home page view) and `signup_click` (button press, recorded *before* the capacity gate — a click we turned away is still demand).
- `pilots` gains a nullable `created_at`, so completed signups can be reported over the same window as landings and clicks. Left NULL for existing rows rather than backfilled with `NOW()`, so the pilot who predates the column isn't reported as signing up the day this ships.
- Visitors counted via a daily-rotating salted hash of IP + user agent. No raw IP stored; the token is useless across days.
- `recordEvent` never throws — analytics must never be why a visitor sees an error instead of a signup button.
- New Analytics tab on `/admin` showing the funnel over the last week, plus capacity used.

## Known limitation: landings are a proxy, not a click count

The description footer is a bare `🌐 ploufbag.com` with no path, so a click from a Strava activity arrives at `/` indistinguishable from direct traffic. With no other inbound channel it's a good proxy, but it is not the same measurement, and the admin UI says so.

Making it exact means changing the footer to a tracked path (e.g. `ploufbag.com/f`) — which requires widening `formattedStatsPattern()` to consume the path too. Without that, the leftover `/f` survives each rewrite and accumulates, corrupting descriptions. That's the same class of bug as #23/#24, so it was left out of this PR deliberately.

## Migrations (manual, per repo convention)

Apply to each database instance before/with deploy:
1. `functions/src/model/database/scripts/create_analytics_events.sql`
2. `functions/src/model/database/scripts/add_created_at_to_pilots.sql`

Until then the Analytics tab shows a yellow notice naming both scripts; the rest of `/admin` is unaffected.

`event_type` is `VARCHAR + CHECK`, not a Postgres `ENUM`: ts-postgres can't decode custom enum OIDs, which is why the monitoring tables had to be rebuilt once already (`migrate_monitoring_tables_to_varchar.sql`). An enum would insert fine and fail on read.

## Test plan

- `site`: 19 new tests pass (`isBot`, `signupState`, OAuth URL pin, `/connect` gate + fail-open, `/api/admin/analytics` validation).
- `common`: `yarn build` clean.
- Pre-existing failures, verified identical on a clean `main` and **not** introduced here:
  - 5 site test files fail — 3 need a container runtime (unavailable on this machine), 2 have a `vi.mock` hoisting bug in `tasks`/`webhooks` unit tests.
  - `yarn build` fails prerendering `/_global-error` (`useContext` of null), same error and digest on `main`. TypeScript compiles cleanly before that point.
- **Not run locally:** `task local-build && docker compose up` — no container runtime on this machine. Needs CI, or a manual local run, before merge.

## Flagged, not fixed

- `common/dist` is **tracked and gitignored simultaneously**, and the committed copy on `main` is stale (missing the `descriptionFooter` re-export). `git add` refuses it without `-f`, so it's untouched here. Worth resolving separately — it's the same shape as the stale-`functions/dist` deploy trap.
- `site/src/app/admin/types.ts` is a dead duplicate of `src/data/model/admin.ts`, imported by nothing.
- `/admin` and its API routes have **no authentication** — middleware only protects `/dashboard` and `/welcome`. This PR adds visitor counts there but no personal data; still worth closing.
