### PR TITLE
fix: Keep the footer on screen without scrolling

### DIFF
--- a/site/src/styles/Layout.module.css
+++ b/site/src/styles/Layout.module.css
@@ -2,11 +2,27 @@
     display: flex !important;
     flex-direction: column !important;
     min-height: 100vh !important;
+    /*
+     * 100dvh, where supported, is the *visible* viewport: on mobile Safari and
+     * Chrome, 100vh is the height with browser chrome retracted, which is taller
+     * than what you can actually see. Sized in vh alone, the footer sits below
+     * the fold on a phone even when the layout maths is otherwise right. The vh
+     * line above stays as the fallback for browsers without dvh.
+     */
+    min-height: 100dvh !important;
     background-color: var(--color-background);
 }
 
+/*
+ * flex: 1 makes this fill the space between header and footer, and being a
+ * flex column itself lets the page inside it do the same. Without that, a page
+ * wanting to fill the viewport has to reach for `100vh` and ends up
+ * double-counting it -- see .page / .pageCentered in Page.module.css.
+ */
 .container {
     flex: 1;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     max-width: var(--container-max-width);
     margin: 0 auto;

--- a/site/src/styles/Page.module.css
+++ b/site/src/styles/Page.module.css
@@ -1,13 +1,29 @@
+/*
+ * These fill the space the layout gives them rather than measuring the viewport
+ * themselves.
+ *
+ * They previously set `min-height: calc(100vh - var(--header-height))`, which
+ * subtracted the header but not the breadcrumb or the footer. Inside a body that
+ * is already `min-height: 100vh`, the page floor became
+ * `header + breadcrumb + (100vh - header) + footer`, i.e. a full viewport plus
+ * the footer -- so the footer was pushed below the fold by exactly its own
+ * height on every page, however little content there was.
+ *
+ * `flex: 1 0 auto` fills the leftover space when content is short (keeping the
+ * footer on screen without scrolling) and grows past it when content is long.
+ * Deliberately not `flex: 1`, whose `flex-basis: 0` lets tall content be
+ * compressed by the flex algorithm.
+ */
 .page {
     padding: var(--space-6) 0;
-    min-height: calc(100vh - var(--header-height));
+    flex: 1 0 auto;
     display: flex;
     flex-direction: column;
 }
 
 .pageCentered {
     padding: var(--space-12) 0;
-    min-height: calc(100vh - var(--header-height));
+    flex: 1 0 auto;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## Problem

The "Built by theo.dev" footer was only visible after scrolling, on every page, however short the content.

## Cause

The layout already implemented the sticky-footer pattern correctly — `body` is a flex column with `min-height: 100vh`, `.container` is `flex: 1`, `.footer` has `margin-top: auto`. That alone pins the footer to the bottom of the viewport when content is short.

It was defeated by the pages inside it. `.page` and `.pageCentered` measured the viewport a second time:

```css
min-height: calc(100vh - var(--header-height));
```

That subtracts the header but not the breadcrumb or the footer. Inside a body already floored at `100vh`, the minimum page height became:

```
header + breadcrumb + (100vh − header) + footer  =  100vh + breadcrumb + footer
```

A full viewport *plus* the footer — so the footer sat below the fold by roughly its own height, always.

## Measured, same page, same viewport

In-page A/B on the home page at a 1116px viewport, toggling only the old rule:

| | Document height | Viewport | Forced scroll | Footer visible |
|---|---|---|---|---|
| Old rule | 1186px | 1116px | **70px** | ✗ |
| This PR | 1116px | 1116px | **0px** | ✓ |

70px is the breadcrumb plus footer — exactly the double-counted overflow, not an approximation.

## Fix

- `.container` becomes a flex column, so the page inside it can grow to fill instead of reaching for `100vh`.
- `.page` / `.pageCentered` use `flex: 1 0 auto`. Deliberately **not** `flex: 1`, whose `flex-basis: 0` lets the flex algorithm compress tall content — long pages like `/flights` must still size to their content.
- Adds a `100dvh` floor after the existing `100vh` one on `body`. On mobile Safari and Chrome, `100vh` is the height with browser chrome *retracted*, which is taller than the visible area — a vh-only floor pushes the footer below the fold on a phone even once the maths above is right. The `vh` line stays as the fallback for browsers without `dvh`.

Long pages still scroll normally, and the footer still sits at the end of the content rather than being pinned over it. If you wanted it pinned to the viewport at all times (`position: fixed`), that's a different change and a one-liner — say so and I'll swap it, though it would overlay content on the map and list pages.

## Test plan

- Verified in Chrome against a local dev server: footer fully in view at page load, zero forced scroll (numbers above).
- No TypeScript or behavioural change — CSS only. `.loginPageContainer` is `position: fixed` and untouched.
- CI: build + tests.
