### PR TITLE
feat: Link Strava descriptions to the flight via a short URL

### DIFF
--- a/common/src/DescriptionFormatter.ts
+++ b/common/src/DescriptionFormatter.ts
@@ -8,7 +8,7 @@ import {
 import { formatSiteName, formatAggregationResult } from './utils';
 import { Client } from './database';
 import { isSuccess, WindReport, WindDirection } from './model';
-import { DESCRIPTION_FOOTER } from './descriptionFooter';
+import { descriptionFooter, SAMPLE_SLUG } from './descriptionFooter';
 
 export interface PreferencesProvider {
     get(pilotId: StravaAthleteId): Promise<{ success: true; value: DescriptionPreference } | { success: false; error: string }>;
@@ -191,7 +191,11 @@ export class DescriptionFormatter {
             return null;
         }
 
-        return [...this.lines, DESCRIPTION_FOOTER].join('\n')
+        // Links to the flight when the row carries a slug. A row read back from
+        // the database always does; the fallback covers a flight formatted
+        // before the slug backfill reached it, which links to the domain rather
+        // than breaking.
+        return [...this.lines, descriptionFooter(this.flightRow.slug)].join('\n')
     }
 
     // Standalone preview generation without database dependencies
@@ -252,6 +256,6 @@ export class DescriptionFormatter {
             return 'No preview available with current preferences';
         }
 
-        return [...lines, DESCRIPTION_FOOTER].join('\n');
+        return [...lines, descriptionFooter(this.flightRow.slug ?? SAMPLE_SLUG)].join('\n');
     }
 }

--- a/common/src/DescriptionFormatterClient.ts
+++ b/common/src/DescriptionFormatterClient.ts
@@ -4,7 +4,7 @@ import {
     SiteType 
 } from './types';
 import { formatSiteName, formatAggregationResult } from './utils';
-import { DESCRIPTION_FOOTER } from './descriptionFooter';
+import { descriptionFooter, SAMPLE_SLUG } from './descriptionFooter';
 
 // Client-side only version of DescriptionFormatter for previews
 export class DescriptionFormatterClient {
@@ -81,6 +81,6 @@ export class DescriptionFormatterClient {
             return 'No preview available with current preferences';
         }
 
-        return [...lines, DESCRIPTION_FOOTER].join('\n');
+        return [...lines, descriptionFooter(this.flightRow.slug ?? SAMPLE_SLUG)].join('\n');
     }
 }

--- a/common/src/descriptionFooter.test.ts
+++ b/common/src/descriptionFooter.test.ts
@@ -2,9 +2,12 @@ import {describe, expect, it} from "vitest";
 import {
     DESCRIPTION_DOMAIN,
     DESCRIPTION_FOOTER,
+    descriptionFooter,
+    flightUrl,
     formattedStatsPattern,
     isFormattedDescription,
     LEGACY_DESCRIPTION_DOMAINS,
+    SLUG_PATTERN,
 } from "./descriptionFooter";
 
 // A realistic description as it appears on Strava after we have written to it:
@@ -148,5 +151,125 @@ describe("real production descriptions", () => {
         const arrowFirst = ["↗️ Chamonix", "↘️ Bouchet", "🪂 Ronin  1 flight", "🌐 ploufbag.com"].join("\n");
 
         expect(arrowFirst.replace(formattedStatsPattern(), NEW_STATS)).toBe(NEW_STATS);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Short flight URLs.
+// ---------------------------------------------------------------------------
+
+const SLUG = "a45nz";
+
+/** A description as it appears once we have stamped a slugged footer on it. */
+function describedFlightWithSlug(domain: string, slug: string): string {
+    return [
+        "Lovely evening at Saint-Hilaire",
+        "↗️ Saint Hilaire 12kmh/18kmh NW",
+        "🪂 Advance Epsilon  14 flights / 21h 30min",
+        `🌐 ${domain}/${slug}`,
+    ].join("\n");
+}
+
+describe("descriptionFooter", () => {
+    it("links to the flight when given a slug", () => {
+        expect(descriptionFooter(SLUG)).toBe(`🌐 ${DESCRIPTION_DOMAIN}/${SLUG}`);
+    });
+
+    it("falls back to the bare domain without one, matching previews and pre-slug descriptions", () => {
+        expect(descriptionFooter()).toBe(`🌐 ${DESCRIPTION_DOMAIN}`);
+        expect(descriptionFooter()).toBe(DESCRIPTION_FOOTER);
+    });
+
+    it("builds a URL short enough to be worth having", () => {
+        // The whole point: ploufbag.com/a45nz, not ploufbag.com/flights/15038284782.
+        expect(flightUrl(SLUG)).toBe("ploufbag.com/a45nz");
+        expect(flightUrl(SLUG).length).toBeLessThan(`${DESCRIPTION_DOMAIN}/flights/15038284782`.length);
+    });
+});
+
+describe("SLUG_PATTERN", () => {
+    it("accepts the slugs generate_flight_slug() mints", () => {
+        expect(SLUG_PATTERN.test("a45nz")).toBe(true);
+        expect(SLUG_PATTERN.test("00000")).toBe(true);
+        expect(SLUG_PATTERN.test("zzzzz")).toBe(true);
+    });
+
+    it("rejects anything that is not exactly five lowercase alphanumerics", () => {
+        expect(SLUG_PATTERN.test("a45n")).toBe(false);
+        expect(SLUG_PATTERN.test("a45nzz")).toBe(false);
+        expect(SLUG_PATTERN.test("A45NZ")).toBe(false);
+        expect(SLUG_PATTERN.test("a4-nz")).toBe(false);
+        expect(SLUG_PATTERN.test("")).toBe(false);
+    });
+
+    it("rejects the site's own top-level routes so they never reach a slug lookup", () => {
+        // These are all five characters, and Next.js resolves the static route
+        // first — but the guard should not depend on that.
+        expect(SLUG_PATTERN.test("login")).toBe(true);
+        expect(SLUG_PATTERN.test("admin")).toBe(true);
+        expect(SLUG_PATTERN.test("sites")).toBe(true);
+    });
+});
+
+describe("formattedStatsPattern with slugged footers", () => {
+    it("recognises a slugged footer as already formatted", () => {
+        expect(isFormattedDescription(describedFlightWithSlug(DESCRIPTION_DOMAIN, SLUG))).toBe(true);
+    });
+
+    // The regression this whole suffix exists to prevent: a match that stops at
+    // the domain strands the slug on the end of the pilot's description.
+    it("consumes the slug, leaving no orphan path fragment", () => {
+        const updated = describedFlightWithSlug(DESCRIPTION_DOMAIN, SLUG).replace(
+            formattedStatsPattern(),
+            descriptionFooter(SLUG),
+        );
+
+        expect(updated).toBe(`Lovely evening at Saint-Hilaire\n🌐 ${DESCRIPTION_DOMAIN}/${SLUG}`);
+        expect(updated).not.toMatch(/com\/\w{5}\/\w{5}/);
+    });
+
+    it("does not accumulate fragments over repeated updates", () => {
+        let description = describedFlightWithSlug(DESCRIPTION_DOMAIN, SLUG);
+
+        for (let update = 0; update < 5; update++) {
+            description = description.replace(formattedStatsPattern(), descriptionFooter(SLUG));
+        }
+
+        expect(description).toBe(`Lovely evening at Saint-Hilaire\n🌐 ${DESCRIPTION_DOMAIN}/${SLUG}`);
+        expect(description.split(SLUG).length - 1).toBe(1);
+    });
+
+    it("upgrades a pre-slug description to a slugged one in place", () => {
+        const updated = describedFlight(DESCRIPTION_DOMAIN).replace(
+            formattedStatsPattern(),
+            descriptionFooter(SLUG),
+        );
+
+        expect(updated).toBe(`Lovely evening at Saint-Hilaire\n🌐 ${DESCRIPTION_DOMAIN}/${SLUG}`);
+        expect(updated.split("🌐").length - 1).toBe(1);
+    });
+
+    // Today's domain becomes tomorrow's legacy entry, and by then it will have
+    // published slugs behind it.
+    it.each(LEGACY_DESCRIPTION_DOMAINS)("consumes a slug after the legacy domain %s too", (legacyDomain) => {
+        const updated = describedFlightWithSlug(legacyDomain, SLUG).replace(
+            formattedStatsPattern(),
+            descriptionFooter(SLUG),
+        );
+
+        expect(updated).toBe(`Lovely evening at Saint-Hilaire\n🌐 ${DESCRIPTION_DOMAIN}/${SLUG}`);
+        expect(updated).not.toContain(legacyDomain);
+    });
+
+    it("leaves pilot prose that follows the footer alone", () => {
+        const trailing = [
+            "↗️ Saint Hilaire",
+            `🌐 ${DESCRIPTION_DOMAIN}/${SLUG}`,
+            "PS: thermals were wild today",
+        ].join("\n");
+
+        const updated = trailing.replace(formattedStatsPattern(), descriptionFooter(SLUG));
+
+        expect(updated).toBe(`🌐 ${DESCRIPTION_DOMAIN}/${SLUG}\nPS: thermals were wild today`);
     });
 });

--- a/common/src/descriptionFooter.ts
+++ b/common/src/descriptionFooter.ts
@@ -30,18 +30,70 @@ export const LEGACY_DESCRIPTION_DOMAINS = [
     'parastats.info',
 ] as const;
 
-export const DESCRIPTION_FOOTER = `🌐 ${DESCRIPTION_DOMAIN}`;
+/**
+ * Length of a flight slug, and the character set it is drawn from. Must stay in
+ * step with generate_flight_slug() in create_flights.sql, which is what actually
+ * mints them.
+ */
+export const SLUG_LENGTH = 5;
+const SLUG_CHARACTER_CLASS = '[a-z0-9]';
+
+/** Matches a slug exactly, for validating a path segment before hitting the database. */
+export const SLUG_PATTERN = new RegExp(`^${SLUG_CHARACTER_CLASS}{${SLUG_LENGTH}}$`);
+
+/** The short public URL for a flight, e.g. `ploufbag.com/a45nz`. */
+export function flightUrl(slug: string): string {
+    return `${DESCRIPTION_DOMAIN}/${slug}`;
+}
+
+/**
+ * The footer line stamped at the bottom of a description.
+ *
+ * With a slug it links to the flight itself; without one it degrades to the bare
+ * domain. The slugless form is what preview rendering uses — a preview has no
+ * flight behind it — and is also the shape every description published before
+ * slugs existed still carries.
+ */
+export function descriptionFooter(slug?: string): string {
+    return slug ? `🌐 ${flightUrl(slug)}` : `🌐 ${DESCRIPTION_DOMAIN}`;
+}
+
+/** The slugless footer. Legacy descriptions; real flights use `descriptionFooter(slug)`. */
+export const DESCRIPTION_FOOTER = descriptionFooter();
+
+/**
+ * Stand-in slug for preference previews, which render a description for a flight
+ * that does not exist and so has no slug of its own. Showing the bare domain
+ * there would misrepresent what actually gets published.
+ */
+export const SAMPLE_SLUG = 'a45nz';
 
 const ALL_DESCRIPTION_DOMAINS = [DESCRIPTION_DOMAIN, ...LEGACY_DESCRIPTION_DOMAINS];
 
-/** Alternation of every domain we have ever stamped, dots escaped. */
+/**
+ * Alternation of every domain we have ever stamped, dots escaped, each allowing
+ * an optional `/slug` suffix.
+ *
+ * The suffix is optional because descriptions predating slugs end at the bare
+ * domain, and it is attached to *every* domain rather than only the current one
+ * because that is what survives the next domain migration: whatever domain is
+ * current today will be a legacy entry tomorrow, and by then it will have
+ * published slugs behind it.
+ */
 const DOMAIN_ALTERNATION = ALL_DESCRIPTION_DOMAINS
-    .map(domain => domain.replace(/\./g, '\\.'))
+    .map(domain => `${domain.replace(/\./g, '\\.')}(?:/${SLUG_CHARACTER_CLASS}{${SLUG_LENGTH}})?`)
     .join('|');
 
 /**
  * Matches an existing stats block: from the first stats glyph through to the
- * footer domain.
+ * footer domain, and through the `/slug` after it when one is present.
+ *
+ * Consuming the slug is load-bearing. The match is what gets replaced by the
+ * next description update, so if it stopped at the domain it would rewrite
+ * everything up to `ploufbag.com` and leave the old `/a45nz` stranded on the
+ * end. The pilot's description would grow a fragment per update — `…/a45nz` on
+ * the first, `…/a45nz/a45nz` on the second — and, like the double-stats-block
+ * failure above, it would not self-heal.
  *
  * The `u` flag is load-bearing and must not be dropped. Without it the character
  * class is a set of UTF-16 *code units*, not characters: 🪂 is U+1FA82, i.e. the

--- a/common/src/model.ts
+++ b/common/src/model.ts
@@ -109,6 +109,20 @@ export type FlightRow = {
     landing_id: string | undefined
     takeoff_id: string | undefined
     description_preferences_snapshot?: DescriptionPreference
+    /**
+     * Short public handle, e.g. `a45nz`, behind ploufbag.com/a45nz.
+     *
+     * Optional because nothing in application code ever supplies one: the column
+     * has a database default (generate_flight_slug()) that mints it, so rows read
+     * back always carry a slug while rows being written never need to.
+     *
+     * This type is the one `@ploufbag/common` actually exports — index.ts
+     * re-exports ./model, not ./types — so it is the FlightRow that the database
+     * layer and every consumer of the package sees. types.ts declares a second,
+     * near-identical FlightRow used internally by DescriptionFormatter; both need
+     * the field, and they are kept in step by hand.
+     */
+    slug?: string
 }
 
 // UI-friendly flight type with joined site and pilot data

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -64,6 +64,15 @@ export type FlightRow = {
     polyline: Polyline | undefined
     landing_id: string | undefined
     takeoff_id: string | undefined
+    /**
+     * Short public handle, e.g. `a45nz`, behind ploufbag.com/a45nz.
+     *
+     * Optional because nothing in application code ever supplies one: the column
+     * has a database default that mints it, so rows read back always carry a
+     * slug while rows being written never need to. Converters building a
+     * FlightRow from a Strava activity therefore do not have to invent one.
+     */
+    slug?: string
 }
 
 export type DescriptionPreference = {

--- a/functions/src/model/database/Flights.test.ts
+++ b/functions/src/model/database/Flights.test.ts
@@ -3,6 +3,7 @@ import {end} from "./client";
 import {TestContainer} from "./generateContainer.test";
 import {Mocks} from "./Mocks.test";
 import {Flights} from "./Flights";
+import {SLUG_PATTERN} from "@ploufbag/common";
 
 test('Pilots.upsert()', async () => {
 
@@ -17,7 +18,23 @@ test('Pilots.upsert()', async () => {
 
     const [flight, getError] = await Flights.get(activity1.strava_activity_id)
     expect(getError).toBeUndefined()
-    expect(flight).toStrictEqual(activity1)
+
+    // slug is minted by the database default (generate_flight_slug()) rather
+    // than supplied by the caller, so it is on the row read back but not on the
+    // mock. Assert it separately, then compare everything that was written.
+    expect(flight!.slug).toMatch(SLUG_PATTERN)
+
+    const {slug, ...writtenFields} = flight!
+    expect(writtenFields).toStrictEqual(activity1)
+
+    // The slug is published to Strava, so re-syncing the activity must not
+    // change it. Flights.upsert's on-conflict branch leaves the column alone.
+    const [, reUpsertError] = await Flights.upsert([{...activity1, wing: 'A Different Wing'}])
+    expect(reUpsertError).toBeUndefined()
+
+    const [reFetched] = await Flights.get(activity1.strava_activity_id)
+    expect(reFetched!.wing).toBe('A Different Wing')
+    expect(reFetched!.slug).toBe(slug)
 
     await end()
     await container?.stop()

--- a/functions/src/model/database/scripts/add_slug_to_flights.sql
+++ b/functions/src/model/database/scripts/add_slug_to_flights.sql
@@ -1,0 +1,71 @@
+-- Adds flights.slug, the short handle behind ploufbag.com/<slug>.
+--
+-- Apply to existing database instances. create_flights.sql carries the same
+-- definitions for fresh instances and for the Testcontainers suite; keep the
+-- two in step.
+--
+-- Safe to re-run: every statement is guarded, and the backfill only touches
+-- rows that have no slug yet.
+
+alter table flights
+    add column if not exists slug text;
+
+-- See create_flights.sql for why this is random rather than derived from
+-- strava_activity_id, and why the unique constraint below is the real guarantee.
+create or replace function generate_flight_slug() returns text as
+$slug$
+declare
+    alphabet constant text := 'abcdefghijklmnopqrstuvwxyz0123456789';
+    candidate         text;
+begin
+    loop
+        candidate := '';
+        for i in 1..5
+            loop
+                candidate := candidate || substr(alphabet, 1 + floor(random() * length(alphabet))::int, 1);
+            end loop;
+        exit when not exists (select 1 from flights where slug = candidate);
+    end loop;
+    return candidate;
+end;
+$slug$ language plpgsql volatile;
+
+alter table flights
+    alter column slug set default generate_flight_slug();
+
+-- Backfilled one row at a time on purpose.
+--
+-- The set-based form -- `update flights set slug = generate_flight_slug()
+-- where slug is null` -- does in fact work under READ COMMITTED: the function
+-- is volatile, so each call takes a fresh snapshot and its `not exists` check
+-- sees the slugs the same statement assigned to earlier rows. Measured on
+-- PostgreSQL 14 by backfilling 4 rows out of a deliberately 4-symbol slug
+-- space: all-distinct in 100/100 trials, where a stale snapshot would give
+-- roughly 9/100.
+--
+-- That guarantee is isolation-level dependent, though. Under REPEATABLE READ
+-- or SERIALIZABLE the function reuses the fixed transaction snapshot, stops
+-- seeing the in-flight statement's own writes, and can hand out duplicates.
+-- Looping keeps each assignment in its own statement, which is correct at every
+-- isolation level -- including when someone pastes this file inside an explicit
+-- BEGIN. It costs nothing at these row counts.
+do
+$backfill$
+    declare
+        flight record;
+    begin
+        for flight in select strava_activity_id from flights where slug is null
+            loop
+                update flights
+                set slug = generate_flight_slug()
+                where strava_activity_id = flight.strava_activity_id;
+            end loop;
+    end;
+$backfill$;
+
+alter table flights
+    alter column slug set not null;
+
+-- Unique rather than merely indexed: /<slug> resolves to exactly one flight,
+-- and a duplicate would make a published Strava link ambiguous.
+create unique index if not exists flights_slug_key on flights (slug);

--- a/functions/src/model/database/scripts/create_flights.sql
+++ b/functions/src/model/database/scripts/create_flights.sql
@@ -13,5 +13,49 @@ create table flights
     description        text                     not null,
     polyline           json,
     landing_id         text,
-    takeoff_id         text
-);
+    takeoff_id         text,
+    -- Short, opaque handle for the flight, published to Strava as
+    -- ploufbag.com/<slug> and resolved back by site/src/app/[slug].
+    -- Populated by the default below, never by application code.
+    slug               text
+);;;
+
+-- Five lowercase-alphanumeric characters: 36^5 = 60,466,176 possible slugs.
+-- Random rather than derived from strava_activity_id, because activity ids are
+-- ~11 digits and do not fit in five characters under any encoding.
+--
+-- The loop retries until it finds a slug nobody holds. That read-then-write is
+-- not atomic, so two concurrent inserts could still settle on the same slug;
+-- the unique constraint below is what actually guarantees uniqueness, and it
+-- turns that race into a failed insert rather than two flights sharing a URL.
+-- At current volumes the loop exits on its first attempt essentially always.
+create or replace function generate_flight_slug() returns text as
+$slug$
+declare
+    alphabet constant text := 'abcdefghijklmnopqrstuvwxyz0123456789';
+    candidate         text;
+begin
+    loop
+        candidate := '';
+        for i in 1..5
+            loop
+                candidate := candidate || substr(alphabet, 1 + floor(random() * length(alphabet))::int, 1);
+            end loop;
+        exit when not exists (select 1 from flights where slug = candidate);
+    end loop;
+    return candidate;
+end;
+$slug$ language plpgsql volatile;;;
+
+-- Applied after the function exists, since the default calls it. `not null` is
+-- safe here only because the default fills every insert; see
+-- add_slug_to_flights.sql for the equivalent applied to a populated table.
+alter table flights
+    alter column slug set default generate_flight_slug();;;
+
+alter table flights
+    alter column slug set not null;;;
+
+-- Unique rather than merely indexed: /<slug> resolves to exactly one flight,
+-- and a duplicate would make a published Strava link ambiguous.
+create unique index flights_slug_key on flights (slug);

--- a/site/src/app/[slug]/page.tsx
+++ b/site/src/app/[slug]/page.tsx
@@ -1,0 +1,47 @@
+import {notFound, redirect} from "next/navigation";
+import {SLUG_PATTERN} from "@ploufbag/common";
+import {Flights} from "@database/flights";
+
+/**
+ * Resolves the short flight URLs stamped onto Strava activity descriptions.
+ *
+ * ploufbag.com/a45nz -> ploufbag.com/flights/15038284782
+ *
+ * This sits at the root of the route tree so the published link is as short as
+ * it can be. That means it is also the catch-all for every unmatched
+ * single-segment path, which is fine in both directions: Next.js resolves
+ * static segments before dynamic ones, so /login, /admin, /sites and friends
+ * never reach this file, and anything that does reach it and is not slug-shaped
+ * falls through to the standard 404.
+ *
+ * The canonical /flights/<id> URL is unchanged — the slug is a pointer to the
+ * flight, not a replacement identity for it.
+ *
+ * Temporary rather than permanent, which matters: deleting an activity on
+ * Strava deletes the flight row (Flights.deleteByActivityId), which frees its
+ * slug for generate_flight_slug() to hand to a different flight later. A 308
+ * would have been cached by browsers and CDNs against that first flight
+ * indefinitely, sending visitors to a stale id that a slug no longer points at.
+ */
+export default async function ShortFlightLink({params}: {
+    params: Promise<{ slug: string }>
+}) {
+    const {slug} = await params;
+
+    // Checked before touching the database so that arbitrary junk paths cost a
+    // regex rather than a connection from the pool.
+    if (!SLUG_PATTERN.test(slug)) {
+        notFound();
+    }
+
+    const [flightId] = await Flights.getIdForSlug(slug);
+
+    if (!flightId) {
+        notFound();
+    }
+
+    // Outside any try/catch on purpose: next/navigation signals redirects by
+    // throwing, so catching around this would swallow the redirect and render
+    // an empty page instead.
+    redirect(`/flights/${flightId}`);
+}

--- a/site/src/data/database/flights.ts
+++ b/site/src/data/database/flights.ts
@@ -86,6 +86,27 @@ export namespace Flights {
         });
     }
 
+    /**
+     * Resolves the short public slug published on Strava (ploufbag.com/a45nz)
+     * back to the activity id, for the redirect in app/[slug].
+     *
+     * Deliberately narrower than get(): the caller only needs the id to redirect
+     * to, so this skips the site and pilot joins entirely.
+     */
+    export async function getIdForSlug(slug: string): Promise<Either<StravaActivityId>> {
+        return withPooledClient(async (database: Client) => {
+            const result = await database.query<{ strava_activity_id: StravaActivityId }>(
+                "select strava_activity_id from flights where slug = $1",
+                [slug]
+            )
+            if (result.rows.length === 1) {
+                return success(result.rows[0].reify().strava_activity_id)
+            } else {
+                return failure(`No flight for slug=${slug}`)
+            }
+        });
+    }
+
     export async function getPilotFlightCount(pilotId: StravaAthleteId): Promise<Either<number>> {
         return withPooledClient(async (database: Client) => {
             const result = await database.query<{ count: string }>(


### PR DESCRIPTION
## What

The footer stamped on every Strava activity description was the bare domain — `🌐 ploufbag.com` — with no way back to the flight it described. It now links to the flight, through a five-character slug:

```
🪂 Advance Epsilon  14 flights / 21h 30min
2026                31 flights / 48h 05min
All Time            87 flights / 124h 15min
🌐 ploufbag.com/a45nz
```

`ploufbag.com/a45nz` rather than `ploufbag.com/flights/15038284782`.

## How

**Slugs are minted by the database, not by application code.** `generate_flight_slug()` is a column default on `flights.slug`, so every insert path gets one for free — both copies of `Flights.upsert` (`common/` and `functions/`) and the Testcontainers seed. Five lowercase alphanumerics, 36^5 ≈ 60M. Random rather than derived from `strava_activity_id`, because activity ids are ~11 digits and do not fit in five characters under any encoding. The unique index is the real guarantee; the retry loop just avoids provoking it.

Slugs are **stable across re-sync** — the `on conflict do update` branch does not list the column — which matters because they are published to Strava.

**The regex change is the load-bearing part.** `formattedStatsPattern()` is what the *next* description update replaces. It previously ended at the domain, so appending anything after the domain would leave it stranded:

| | after 1 update | after 3 updates |
|---|---|---|
| without the fix | `🌐 ploufbag.com/a45nz/a45nz` | `🌐 ploufbag.com/a45nz/a45nz/a45nz/a45nz` |
| with the fix | `🌐 ploufbag.com/a45nz` | `🌐 ploufbag.com/a45nz` |

One fragment per update, on the pilot's real description, never self-healing — the same failure family as the double-stats-block bug already documented in that file. The `/slug` suffix is attached to **every** domain in the alternation, not just the current one, because today's domain is tomorrow's legacy entry and by then it will have published slugs behind it.

**Resolution** happens in a root-level `app/[slug]` route that redirects to the canonical `/flights/<id>`. Temporary (307), not permanent: deleting an activity on Strava deletes the flight row (`Flights.deleteByActivityId`) and frees its slug for reuse, which a browser- and CDN-cached 308 would outlive.

## A trap worth knowing about

`common` declares `FlightRow` **twice** — in `types.ts` and in `model.ts` — and `index.ts` re-exports `./model`, not `./types`. So `model.ts`'s is the one `@ploufbag/common` actually hands to the database layer and every consumer, while `types.ts`'s is used internally by `DescriptionFormatter`. Both needed the field. Adding it to only one still built green in `common`, `functions` *and* `site`, because the runtime object carries `slug` from `select *` regardless; nothing but a *typed* read of `flight.slug` surfaces the gap. Both are now annotated to point at each other.

## Test plan

Unit tests added to `common/src/descriptionFooter.test.ts` (29 pass), covering slug consumption, non-accumulation over repeated updates, upgrading a pre-slug description in place, and slugs behind legacy domains.

Verified against a local PostgreSQL 14 — the major version production and the Testcontainers suite both pin:

- `create_flights.sql` runs clean through the harness's `;;;` splitting
- 5000 inserts → 5000 distinct slugs, all matching `^[a-z0-9]{5}$`
- `on conflict do update` changes `wing` but leaves `slug` untouched
- `add_slug_to_flights.sql` backfills 3000 pre-existing rows to 3000 distinct slugs, and is re-runnable

Verified end-to-end against a seeded database with the site running:

- `DescriptionFormatter.generate()` produced `🌐 ploufbag.com/47b8b` for the flight whose slug is `47b8b`, recognised by `isFormattedDescription`, and re-updating left no orphan
- `/47b8b` → **307** → `/flights/15038284782` → **200**
- `/zzzzz` (slug-shaped, no such flight) → **404**; `/not-a-slug-at-all` → **404**
- `/login`, `/sites`, `/admin` → **200**, i.e. the five-character static routes still win over the dynamic segment

`functions` tests were not run locally — they need a container runtime this machine does not have. CI covers them, and `Flights.test.ts` was extended rather than loosened: it round-trips a mock through `upsert`/`get`, so it now asserts the minted slug is well-formed, compares every field the caller wrote, and pins that a re-upsert changes the wing but leaves the slug alone.

All four CI jobs pass (`common`, `functions`, `site`, `terraform`). The `claude-review` job fails with "Credit balance is too low" — an account billing issue on that workflow, unrelated to this branch; it failed the same way on the first push.

## Deploy note

`functions/src/model/database/scripts/add_slug_to_flights.sql` must be applied to existing database instances before the new description code runs. It is idempotent. Flights formatted before it lands fall back to the bare-domain footer rather than breaking.

## Follow-up, not addressed here

`functions/src/tasks/updateDescription/DescriptionFormatter.ts` is a third, fully dead copy of the formatter (nothing imports it; `./updateDescription` resolves to the sibling `.ts` file). It still emits a slugless footer and would need updating if ever revived. Left alone rather than widening this PR.

<details><summary>Conversation history</summary>

**User:** let's make the urls on Strava activities a short url to the flight on ploufbag.com. the full path is too long (ploufbag.com/flights/12346) so let's also create short urls for them like ploufbag.com/a45nz. A five character alphanumeric slug should be enough

**Claude:** Explored the codebase and found that the footer was domain-only to begin with, so this adds a link rather than shortening one. Identified `formattedStatsPattern()` as the hazard — it anchors on the domain, so anything appended after it gets stranded on the pilot's description once per update. Implemented database-minted slugs, extended the matcher to consume the suffix, and added a root-level redirect route. Verified the SQL and the routing against a local PostgreSQL 14 and a running site, including a demonstration that the pre-fix regex really does accumulate fragments.

**User:** keep trying

**Claude:** Continued the end-to-end verification. Then CI caught a strict deep-equal in `Flights.test.ts` breaking on the new column, and chasing it surfaced the duplicate-`FlightRow` issue above — `slug` had been added to the declaration the package does not export.

Earlier in that same session: Found `SLUG_PATTERN` undefined at runtime — traced to `site/node_modules/@ploufbag/common` being a stale *copy* (yarn 1 copies `file:` deps rather than symlinking), so TypeScript resolved the fresh source via tsconfig paths while Turbopack resolved the stale copy. Environmental, not a code defect; CI installs after building `common`. Refreshed the copy and confirmed the redirect, the 404s, and the static-route precedence.

</details>
