### PR TITLE
feat: Offer signup on flight, pilot and site detail pages

### DIFF
--- a/site/src/app/connect/route.ts
+++ b/site/src/app/connect/route.ts
@@ -1,7 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
 import {recordEvent} from "@database/analytics";
 import {getCount} from "@database/pilots";
-import {STRAVA_AUTHORIZE_URL, signupState} from "@model/signup";
+import {STRAVA_AUTHORIZE_URL, signupClickPath, signupState} from "@model/signup";
 
 /**
  * The signup entry point. Every "Connect with Strava" button links here rather
@@ -18,7 +18,13 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: NextRequest) {
     // Recorded before the capacity check on purpose: someone we had to turn
     // away still tried to sign up, and that is the demand signal worth having.
-    await recordEvent('signup_click', '/connect', request.headers);
+    //
+    // The recorded path carries `?from=` when the press came from a detail-page
+    // banner, so the funnel can tell those signups from home page ones. The
+    // parameter is attacker-controlled, so signupClickPath allowlists it rather
+    // than writing it through to analytics_events.path verbatim.
+    const from = request.nextUrl.searchParams.get('from');
+    await recordEvent('signup_click', signupClickPath(from), request.headers);
 
     let isOpen: boolean;
     try {

--- a/site/src/app/flights/[flight_id]/page.tsx
+++ b/site/src/app/flights/[flight_id]/page.tsx
@@ -8,6 +8,7 @@ import ViewOnStrava from "@ui/links/ViewOnStrava";
 import ClientOnlyDate from "@ui/ClientOnlyDate";
 import Link from "next/link";
 import FlightMap from "@ui/FlightMap";
+import SignupBanner from "@ui/SignupBanner";
 import mapStyles from "@ui/FlightMap.module.css";
 import {formatSiteName} from "@utils/formatSiteName";
 
@@ -50,6 +51,7 @@ export default async function FlightDetail({params}: {
 
     return <div className={styles.page}>
         <div className={styles.container}>
+            <SignupBanner from="flight"/>
             {/* Header Section */}
             <header className={styles.pageHeader}>
                 <h1 className={styles.title}>

--- a/site/src/app/pilots/[pilot_id]/page.tsx
+++ b/site/src/app/pilots/[pilot_id]/page.tsx
@@ -9,6 +9,7 @@ import FlightItem from "@ui/FlightItem";
 import Link from "next/link";
 import {Sites} from "@database/Sites";
 import PilotMap from "@ui/PilotMap";
+import SignupBanner from "@ui/SignupBanner";
 import mapStyles from "@ui/FlightMap.module.css";
 import {formatSiteName} from "@utils/formatSiteName";
 
@@ -76,6 +77,7 @@ export default async function PagePilot({params}: {
 
     return <div className={styles.page}>
         <div className={styles.container}>
+            <SignupBanner from="pilot"/>
             {/* Header Section */}
             <header className={styles.pageHeaderWithProfile}>
                 {pilot.profile_image_url && (

--- a/site/src/app/sites/[site_slug]/page.tsx
+++ b/site/src/app/sites/[site_slug]/page.tsx
@@ -7,6 +7,7 @@ import {Flights} from "@database/flights";
 import FlightItem from "@ui/FlightItem";
 import {StravaAthleteId} from "@ploufbag/common";
 import SiteMap from "@ui/SiteMap";
+import SignupBanner from "@ui/SignupBanner";
 import mapStyles from "@ui/FlightMap.module.css";
 import {formatSiteName} from "../../../utils/formatSiteName";
 
@@ -36,6 +37,7 @@ export default async function SiteDetail({params}: {
 
     return <div className={styles.page}>
         <div className={styles.container}>
+            <SignupBanner from="site"/>
             {/* Header Section */}
             <header className={styles.pageHeader}>
                 <h1 className={styles.title}>{formatSiteName(site.name)}</h1>

--- a/site/src/data/model/signup.ts
+++ b/site/src/data/model/signup.ts
@@ -40,6 +40,34 @@ export const STRAVA_AUTHORIZE_URL =
     `&approval_prompt=force` +
     `&scope=${OAUTH_SCOPE}`;
 
+/**
+ * Where a "Connect with Strava" press came from, so the funnel can tell a home
+ * page signup apart from one the detail-page banner earned.
+ *
+ * An allowlist rather than free text because the value arrives as a query
+ * parameter and is written straight into analytics_events.path. Without it,
+ * anyone could hand-craft /connect?from=... and write arbitrary strings into
+ * the analytics table.
+ */
+export const SIGNUP_SOURCES = ['flight', 'pilot', 'site'] as const;
+
+export type SignupSource = typeof SIGNUP_SOURCES[number];
+
+/** The href a signup button should point at, tagged with its origin. */
+export function connectHref(source?: SignupSource): string {
+    return source ? `/connect?from=${source}` : '/connect';
+}
+
+/**
+ * The path to record for a signup click, given the untrusted `from` parameter.
+ * Anything not on the allowlist is recorded as a plain /connect.
+ */
+export function signupClickPath(from: string | null): string {
+    return (SIGNUP_SOURCES as readonly string[]).includes(from ?? '')
+        ? `/connect?from=${from}`
+        : '/connect';
+}
+
 export type SignupState = {
     /** Whether we should be offering the Strava button at all. */
     isOpen: boolean;

--- a/site/src/styles/Page.module.css
+++ b/site/src/styles/Page.module.css
@@ -162,6 +162,18 @@
     color: var(--color-text-inverse);
 }
 
+/*
+ * Banner-sized variant. The upsell sits above content the visitor actually came
+ * for, so the button has to read as an offer rather than as the page's subject —
+ * hence no min-width, which is what makes the full-size button dominate a row.
+ */
+.stravaButtonCompact {
+    padding: var(--space-3) var(--space-5);
+    font-size: var(--font-size-sm);
+    min-width: 0;
+    white-space: nowrap;
+}
+
 .stravaButton:hover {
     background-color: var(--color-strava-hover);
     text-decoration: none;

--- a/site/src/ui/ConnectWithStrava.tsx
+++ b/site/src/ui/ConnectWithStrava.tsx
@@ -1,16 +1,31 @@
 import styles from "@styles/Page.module.css";
+import {connectHref, SignupSource} from "@model/signup";
+
+type Props = {
+    /**
+     * Where this button is being shown. Tags the click so the funnel can
+     * attribute a signup to the page that earned it; omitted on the home and
+     * login pages, which are the untagged default.
+     */
+    from?: SignupSource;
+    /** Smaller variant, for the upsell banner where the button is not the page's subject. */
+    compact?: boolean;
+};
 
 /**
- * The signup button, in one place so the home page and the login page cannot
- * drift apart.
+ * The signup button, in one place so the home page, the login page and the
+ * detail-page banner cannot drift apart.
  *
  * Points at our own /connect route rather than strava.com: that round-trip is
  * what records the signup attempt and enforces the capacity gate. See
  * src/app/connect/route.ts.
  */
-export default function ConnectWithStrava() {
-    return <a className={styles.stravaButton} href="/connect">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+export default function ConnectWithStrava({from, compact}: Props = {}) {
+    return <a
+        className={compact ? `${styles.stravaButton} ${styles.stravaButtonCompact}` : styles.stravaButton}
+        href={connectHref(from)}
+    >
+        <svg width={compact ? "16" : "20"} height={compact ? "16" : "20"} viewBox="0 0 24 24" fill="currentColor">
             <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.599h4.172L10.463 0l-7 13.828h4.172"/>
         </svg>
         Connect with Strava

--- a/site/src/ui/SignupBanner.module.css
+++ b/site/src/ui/SignupBanner.module.css
@@ -1,0 +1,75 @@
+/*
+ * The upsell banner. Deliberately quieter than .alert: this is an offer sitting
+ * above content the visitor came for, not a status message about their request,
+ * so it uses the surface/border pair rather than a semantic warning colour.
+ *
+ * The Strava orange appears only on the button and the accent rule, which keeps
+ * the one saturated colour on the page pointing at the one thing to click.
+ */
+.banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-8);
+    flex-wrap: wrap;
+
+    margin-bottom: var(--space-8);
+    padding: var(--space-5) var(--space-6);
+
+    background-color: var(--color-surface-elevated);
+    border: 1px solid var(--color-border-light);
+    border-left: 3px solid var(--color-strava);
+    border-radius: var(--border-radius-md);
+}
+
+.text {
+    /* Lets the copy take the slack while the button keeps its intrinsic width. */
+    flex: 1 1 20rem;
+}
+
+.headline {
+    margin: 0;
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.body {
+    margin: var(--space-2) 0 0 0;
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+}
+
+.action {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.spots {
+    margin: 0;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
+}
+
+/*
+ * Below the wrap point the two columns are already stacked by flex-wrap; this
+ * just stops the action column sitting centred under left-aligned copy, and
+ * lets the button span the width the way the rest of the mobile layout does.
+ */
+@media (max-width: 30rem) {
+    .banner {
+        gap: var(--space-5);
+    }
+
+    .action {
+        align-items: stretch;
+        width: 100%;
+    }
+
+    .spots {
+        text-align: center;
+    }
+}

--- a/site/src/ui/SignupBanner.tsx
+++ b/site/src/ui/SignupBanner.tsx
@@ -1,0 +1,58 @@
+import {Auth} from "@auth/index";
+import {getCount} from "@database/pilots";
+import {signupState, SignupSource} from "@model/signup";
+import {BRAND_NAME} from "@ui/brand";
+import ConnectWithStrava from "@ui/ConnectWithStrava";
+import styles from "@ui/SignupBanner.module.css";
+
+/**
+ * The upsell shown at the top of flight, pilot and site detail pages.
+ *
+ * These pages became worth showing to strangers when flight descriptions on
+ * Strava started linking straight to them (ploufbag.com/<slug>) instead of to
+ * the landing page. A visitor arriving that way lands on someone else's flight
+ * having never seen the pitch, so the pitch has to come to them.
+ *
+ * Renders nothing at all when:
+ *  - the visitor is signed in, since there is nothing to sell them; or
+ *  - signups are at capacity, because the button would go to /connect, be
+ *    turned away, and bounce them to the home page. Offering a door that is
+ *    known to be locked is worse on a page they came to for other reasons than
+ *    on the home page, where signing up is the whole point.
+ */
+export default async function SignupBanner({from}: { from: SignupSource }) {
+    // Checked first so that a signed-in visitor costs no database round trip.
+    if (await Auth.checkIsAuthed()) {
+        return null;
+    }
+
+    // Fail open, matching /, /login and /connect: a database blip should not
+    // decide whether we advertise. Strava enforces the real athlete cap anyway.
+    const pilotCount = await getCount().catch(error => {
+        console.error('SignupBanner: pilot count failed, showing signup anyway:', error);
+        return 0;
+    });
+
+    const state = signupState(pilotCount);
+    if (!state.isOpen) {
+        return null;
+    }
+
+    return (
+        <aside className={styles.banner} aria-label={`Sign up for ${BRAND_NAME}`}>
+            <div className={styles.text}>
+                <p className={styles.headline}>Track your own flights</p>
+                <p className={styles.body}>
+                    {BRAND_NAME} finds your paragliding flights on Strava, works out where you took
+                    off and landed, and writes the stats back onto your activity.
+                </p>
+            </div>
+            <div className={styles.action}>
+                <ConnectWithStrava from={from} compact/>
+                <p className={styles.spots}>
+                    Early access &mdash; {state.spotsRemaining} of {state.capacity} spots left
+                </p>
+            </div>
+        </aside>
+    );
+}


### PR DESCRIPTION
## Why

Flight descriptions on Strava now link straight to a flight (`ploufbag.com/a45nz`) instead of to the landing page. That changed who sees the detail pages: a stranger following a link from a friend's activity arrives on someone else's flight having never seen the pitch. This brings the pitch to them.

## What it looks like

```
┌ ─────────────────────────────────────────────────────────────────────┐
│▌ Track your own flights                    [ ⚡ Connect with Strava ] │
│▌ Plouf Bag finds your paragliding flights   Early access — 9 of 10   │
│▌ on Strava, works out where you took off        spots left           │
│▌ and landed, and writes the stats back...                            │
└──────────────────────────────────────────────────────────────────────┘

        Vivo by Theo
```

Quieter than `.alert` on purpose: this is an offer sitting above content the visitor came for, not a status message about their request, so it uses the surface/border pair rather than a semantic warning colour. The one saturated colour on the page — the Strava orange, on the left rule and the button — points at the one thing to click.

## Two cases where it renders nothing

**Signed in.** Nothing to sell. Checked *first*, so a signed-in visitor costs no database round trip.

**At capacity.** This is the one worth arguing about. The button goes to `/connect`, which enforces the gate and bounces a turned-away visitor to `/?full=1`. On the home page that flow is fine — signing up is the point, and there is an explanation waiting. On a flight page it means someone came to look at a flight, was offered a door, and got redirected away from what they were reading. Silence is better there. The home page still explains the situation for anyone who goes looking.

The pilot count fails open exactly as `/`, `/login` and `/connect` already do — a database blip should not decide whether we advertise, and Strava enforces the real cap regardless.

## Attribution

Without this the banner is unmeasurable: `/connect` recorded every click as the literal path `'/connect'`, so a banner signup and a home page signup were indistinguishable. The button now carries its origin (`/connect?from=flight`).

That parameter is attacker-controlled and lands in `analytics_events.path`, so `signupClickPath` allowlists it against `['flight','pilot','site']` rather than writing it through verbatim — otherwise anyone could hand-craft a URL and write arbitrary strings into your analytics table.

`ConnectWithStrava` gained the origin and a compact size rather than the banner rolling its own button, keeping the "one place so they cannot drift apart" invariant its own comment asks for.

## Test plan

Verified locally against a seeded PostgreSQL and a running site:

| Case | Expected | Result |
|---|---|---|
| `/flights/<id>` logged out | banner, `from=flight` | ✅ |
| `/pilots/<id>` logged out | banner, `from=pilot` | ✅ |
| `/sites/<slug>` logged out | banner, `from=site` | ✅ |
| `/flights` (list page) | no banner | ✅ |
| `/flights/<id>` with a valid `sid` cookie | no banner | ✅ |
| 10th pilot fills last spot | no banner | ✅ |
| back down to 9 pilots | banner returns, "1 of 10 spots left" | ✅ |

The signed-in case used a real JWT signed with the local `SESSION_SECRET`, not a mocked auth call.

Screenshots of the flight and site pages are in the conversation. `yarn build` passes; `common` tests still 29/29 (untouched).

## Not done

- **Mobile layout is not visually confirmed.** The browser tooling would not reflow the viewport on resize, so I stopped rather than keep retrying. The CSS is `flex-wrap` with a `max-width: 30rem` rule that stretches the button and centres the spots line; it is simple and conventional, but it has not been seen with human eyes at that width. Worth a glance on a phone before merging.
- **Not dismissible.** Would need client state and a persisted preference; not asked for, and the banner is small enough that it seemed like the wrong first move.
- **No impression events.** Measuring banner *views* would mean a write on every detail page render plus a new event type; the `from=` tag on clicks gives attribution without that cost.
