### PR TITLE
feat: Show the header nav on the home page too

### DIFF
--- a/site/src/middleware.ts
+++ b/site/src/middleware.ts
@@ -9,8 +9,10 @@ export default async function middleware(req: NextRequest) {
     const isProtectedRoute = path.startsWith('/dashboard') || path.startsWith('/welcome')
     const isPublicRoute = !isProtectedRoute
 
+    // x-pathname was set here purely so Header could tell whether it was on the
+    // home page and hide its nav there. The nav is unconditional now, and Header
+    // was the only reader, so the header itself went with it.
     const response = NextResponse.next()
-    response.headers.set('x-pathname', path)
 
     if (isPublicRoute) {
         console.log('middleware() isPublicRoute')

--- a/site/src/ui/Header.tsx
+++ b/site/src/ui/Header.tsx
@@ -1,7 +1,6 @@
 import {Auth} from "@auth/index";
 import styles from "@styles/Header.module.css";
 import {SignOut} from "@ui/SignOut";
-import {headers} from "next/headers";
 import {BRAND_NAME} from "@ui/brand";
 
 
@@ -32,12 +31,17 @@ function NavItem(props: { text: string, path: string }) {
     </a>
 }
 
+/**
+ * The nav is shown on every page, the home page included.
+ *
+ * It used to be hidden there, from when the home page was a signup wall with
+ * nothing behind it to navigate to. Flights, pilots and sites are public now, so
+ * hiding the nav on the one page a new visitor is most likely to land on was
+ * hiding the site from exactly the person who had not seen it yet.
+ */
 export default async function Header() {
     const isAuthed = await Auth.checkIsAuthed()
-    const headersList = await headers()
-    const pathname = headersList.get('x-pathname') || '/'
-    const isHomePage = pathname === '/'
-    
+
     const navItems: NavItem[] = [
         {text: "Home", path: "/", auth: AuthRequired.Always},
         {text: "Dashboard", path: "/dashboard", auth: AuthRequired.Authed},
@@ -53,17 +57,15 @@ export default async function Header() {
                 <span>🪂</span>
                 <span>{BRAND_NAME}</span>
             </a>
-            {!isHomePage && (
-                <nav className={styles.nav}>
-                    <div className={styles.mobileNav}>
-                        {navItems.filter((item) => shouldShow(item.auth, isAuthed))
-                            .map((item) => <NavItem key={item.text} {...item}/>
-                            )
-                        }
-                        {isAuthed && <SignOut/>}
-                    </div>
-                </nav>
-            )}
+            <nav className={styles.nav}>
+                <div className={styles.mobileNav}>
+                    {navItems.filter((item) => shouldShow(item.auth, isAuthed))
+                        .map((item) => <NavItem key={item.text} {...item}/>
+                        )
+                    }
+                    {isAuthed && <SignOut/>}
+                </div>
+            </nav>
         </div>
     </div>
 }


### PR DESCRIPTION
## Why

The nav was hidden on `/` and shown everywhere else:

```tsx
{!isHomePage && (<nav>…</nav>)}
```

That made sense when the home page was a signup wall with nothing public behind it. Flights, pilots and sites are browsable without an account now, so the one page a new visitor is most likely to land on was the one page giving them no way further in.

The gate is gone. Every page renders the same nav.

## Knock-on cleanup

`isHomePage` was the only thing `Header` used the request pathname for, and `Header` was the only reader of `x-pathname` anywhere in the app:

```
site/src/middleware.ts:13:    response.headers.set('x-pathname', path)   ← writer
site/src/ui/Header.tsx:38:    const pathname = headersList.get('x-pathname')  ← only reader
```

So the middleware no longer sets it, and `Header` no longer calls `headers()` at all. Left behind a comment at the removal site saying what it was for, so nobody re-adds it wondering why the site needs a pathname header.

If you would rather keep `x-pathname` around as a debugging aid, it is a one-line revert — it is the only part of this PR that is not strictly the nav change.

## Test plan

Verified locally against a seeded database and a running site:

| Case | Result |
|---|---|
| `/` logged out | `Home · Login · Pilots · Flights · Sites` |
| `/flights` logged out (control) | identical set |
| `/` with a valid `sid` cookie | `Home · Dashboard · Pilots · Flights · Sites` + sign-out, no `Login` |
| `x-pathname` response header | absent |

The signed-in case used a real JWT signed with the local `SESSION_SECRET`, not a mocked auth call — worth doing here because the nav is auth-dependent and the home page had never exercised that path before.

Screenshot of the home page is in the conversation: the pitch, spots-remaining and Strava button are unchanged, with the nav now above them. `yarn build` passes.

## Note

The nav includes a `Home` link that is now visible while on the home page, alongside the brand logo which also points at `/`. That is ordinary nav behaviour and consistent with every other page linking to itself, but it is the one cosmetic thing worth a look before merging.
